### PR TITLE
[Conso-245] clear destinations from Advanced mode

### DIFF
--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -989,6 +989,11 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
         self.share(user_info: SharedInfo(type: .Destinations, value: manager.destinations.map { $0.title.text }.joined(separator: ",")))
     }
 
+    func clearAll(){
+        self.stopSpeak()
+        self.tourManager.clearAllDestinations()
+    }
+
     func tour(manager: TourManager, destinationChanged destination: Destination?) {
         if let dest = destination {
             if let dest_id = dest.value {
@@ -1025,10 +1030,6 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
         } else {
             _ = send(destination: "__cancel__")
         }
-    }
-
-    func stopSpeak(manager: TourManager) {
-        self.stopSpeak()
     }
 
     private func send(destination: String) -> Bool {
@@ -1333,7 +1334,7 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
                         if let value = dest.value {
                             if value == userInfo.value {
                                 if userInfo.flag1 { // clear and add
-                                    tourManager.clearAll()
+                                    self.clearAll()
                                 }
                                 tourManager.addToLast(destination: dest)
                                 needToStartAnnounce(wait: true)
@@ -1361,7 +1362,7 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
             self.share(user_info: SharedInfo(type: .Destinations, value: self.tourManager.destinations.map { $0.title.text }.joined(separator: ",")))
         }
         if userInfo.type == .ClearDestinations {
-            self.tourManager.clearAll()
+            self.clearAll()
         }
     }
 

--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -1027,6 +1027,10 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
         }
     }
 
+    func stopSpeak(manager: TourManager) {
+        self.stopSpeak()
+    }
+
     private func send(destination: String) -> Bool {
         DispatchQueue.main.async {
             print("Show modal waiting")

--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -1356,6 +1356,9 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
             self.share(user_info: SharedInfo(type: .NextDestination, value: self.tourManager.nextDestination?.title.text ?? ""))
             self.share(user_info: SharedInfo(type: .Destinations, value: self.tourManager.destinations.map { $0.title.text }.joined(separator: ",")))
         }
+        if userInfo.type == .ClearDestinations {
+            self.tourManager.clearAll()
+        }
     }
 
     func getSpeechPriority() -> SpeechPriority {
@@ -1700,6 +1703,9 @@ class UserInfoBuffer {
             // do nothing
             break
         case .RequestUserInfo:
+            // do nothing
+            break
+        case .ClearDestinations:
             // do nothing
             break
         }

--- a/CaBot/CaBotServiceCommon.swift
+++ b/CaBot/CaBotServiceCommon.swift
@@ -45,6 +45,7 @@ struct SharedInfo: Codable {
         case OverrideDestination
         case Skip
         case RequestUserInfo
+        case ClearDestinations
     }
     init(type: InfoType, value: String, flag1: Bool = false, flag2: Bool = false, location: Int = 0, length: Int = 0) {
         self.type = type

--- a/CaBot/TourManager.swift
+++ b/CaBot/TourManager.swift
@@ -25,7 +25,6 @@ import Foundation
 protocol TourManagerDelegate {
     func tour(manager: TourManager, destinationChanged: Destination?)
     func tourUpdated(manager: TourManager)
-    func stopSpeak(manager: TourManager)
 }
 
 class TourManager: TourProtocol {
@@ -144,12 +143,11 @@ class TourManager: TourProtocol {
         delegate?.tour(manager: self, destinationChanged: nil)
     }
 
-    func clearAll() {
+    func clearAllDestinations() {
         _destinations.removeAll()
         _currentDestination = nil
         _arrivedDestination = nil
         title = I18NText(text: [:], pron: [:])
-        delegate?.stopSpeak(manager: self)
         delegate?.tourUpdated(manager: self)
         delegate?.tour(manager: self, destinationChanged: nil)
     }

--- a/CaBot/TourManager.swift
+++ b/CaBot/TourManager.swift
@@ -25,6 +25,7 @@ import Foundation
 protocol TourManagerDelegate {
     func tour(manager: TourManager, destinationChanged: Destination?)
     func tourUpdated(manager: TourManager)
+    func stopSpeak(manager: TourManager)
 }
 
 class TourManager: TourProtocol {
@@ -148,6 +149,7 @@ class TourManager: TourProtocol {
         _currentDestination = nil
         _arrivedDestination = nil
         title = I18NText(text: [:], pron: [:])
+        delegate?.stopSpeak(manager: self)
         delegate?.tourUpdated(manager: self)
         delegate?.tour(manager: self, destinationChanged: nil)
     }

--- a/CaBot/Views/DestinationDetailView.swift
+++ b/CaBot/Views/DestinationDetailView.swift
@@ -63,7 +63,7 @@ struct DestinationDetailView: View {
                     detail in
                         Button {
                             if let dest = targetDestination {
-                                tourManager.clearAll()
+                                modelData.clearAll()
                                 tourManager.addToLast(destination: dest)
                                 targetDestination = nil
                                 NavigationUtil.popToRootView()

--- a/CaBot/Views/DestinationsView.swift
+++ b/CaBot/Views/DestinationsView.swift
@@ -92,7 +92,7 @@ struct DestinationsView: View {
                                 detail in
                                     Button {
                                         if let dest = targetDestination {
-                                            tourManager.clearAll()
+                                            modelData.clearAll()
                                             tourManager.addToLast(destination: dest)
                                             targetDestination = nil
                                             NavigationUtil.popToRootView()

--- a/CaBot/Views/TourDetailView.swift
+++ b/CaBot/Views/TourDetailView.swift
@@ -137,7 +137,7 @@ struct DynamicTourDetailView: View {
                 }
                 .confirmationDialog(Text("CANCEL_NAVIGATION"), isPresented: $isConfirming) {
                     Button {
-                        modelData.tourManager.clearAll()
+                        modelData.clearAll()
                         NavigationUtil.popToRootView()
                     } label: {
                         Text("CANCEL_ALL")


### PR DESCRIPTION
- [ツアーの自動テスト実装](https://github.com/CMU-cabot/TODO-Consortium/issues/245)に伴い，ユーザモード上で設定された目的地をアテンドモードからクリアできるようにする機能が必要になったため実装
- アプリのUI上でクリアできるようにするにはViewの変更が伴うため含まれていないです
  - これについては急を要するアップデート内容ではないため，下記のissueを立てた上で[アプリ開発フェーズ1](https://github.com/CMU-cabot/TODO-Consortium/issues/244)に含め，ユーザ/アテンドアプリ分割後にPQさんのどなたかに実装してもらう予定です
  - https://github.com/CMU-cabot/TODO-Consortium/issues/349
  - @daisukes このような方針で問題ないでしょうか？