### PR TITLE
testflight fix

### DIFF
--- a/CaBot.xcodeproj/project.pbxproj
+++ b/CaBot.xcodeproj/project.pbxproj
@@ -792,9 +792,11 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -809,9 +811,10 @@
 					"@executable_path/Frameworks",
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot;
+				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Cabot Test Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -825,9 +828,11 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -842,9 +847,10 @@
 					"@executable_path/Frameworks",
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot;
+				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Cabot Test Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;

--- a/CaBot.xcodeproj/project.pbxproj
+++ b/CaBot.xcodeproj/project.pbxproj
@@ -792,11 +792,9 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -814,7 +812,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Cabot Test Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -828,11 +825,9 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -850,7 +845,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Cabot Test Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;

--- a/CaBot.xcodeproj/xcshareddata/xcschemes/CaBot.xcscheme
+++ b/CaBot.xcodeproj/xcshareddata/xcschemes/CaBot.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7E29F008228B548100CA7DD6"
+               BuildableName = "CaBot.app"
+               BlueprintName = "CaBot"
+               ReferencedContainer = "container:CaBot.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7E29F008228B548100CA7DD6"
+            BuildableName = "CaBot.app"
+            BlueprintName = "CaBot"
+            ReferencedContainer = "container:CaBot.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7E29F008228B548100CA7DD6"
+            BuildableName = "CaBot.app"
+            BlueprintName = "CaBot"
+            ReferencedContainer = "container:CaBot.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CaBot/Info.plist
+++ b/CaBot/Info.plist
@@ -69,16 +69,16 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UILaunchScreen</key>
-<dict>
-    <key>UILaunchScreenBackgroundColor</key>
-    <string>UIColor.systemBackgroundColor</string>
-    <key>UILaunchImage</key>
-    <dict>
-        <key>UILaunchImageName</key>
-        <string>AppIcon</string>
-        <key>UILaunchImageMinimumOSVersion</key>
-        <string>14.0</string>
-    </dict>
-</dict>
+	<dict>
+	    <key>UILaunchScreenBackgroundColor</key>
+	    <string>UIColor.systemBackgroundColor</string>
+	    <key>UILaunchImage</key>
+	    <dict>
+	        <key>UILaunchImageName</key>
+	        <string>AppIcon</string>
+	        <key>UILaunchImageMinimumOSVersion</key>
+	        <string>14.0</string>
+	    </dict>
+	</dict>
 </dict>
 </plist>

--- a/CaBot/Info.plist
+++ b/CaBot/Info.plist
@@ -39,6 +39,8 @@
 	<string>This app uses your microphone</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>This app uses speech recognition</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This app uses your camera</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
@@ -66,5 +68,17 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UILaunchScreen</key>
+<dict>
+    <key>UILaunchScreenBackgroundColor</key>
+    <string>UIColor.systemBackgroundColor</string>
+    <key>UILaunchImage</key>
+    <dict>
+        <key>UILaunchImageName</key>
+        <string>AppIcon</string>
+        <key>UILaunchImageMinimumOSVersion</key>
+        <string>14.0</string>
+    </dict>
+</dict>
 </dict>
 </plist>

--- a/CaBot/en.lproj/InfoPlist.strings
+++ b/CaBot/en.lproj/InfoPlist.strings
@@ -29,3 +29,4 @@ NSLocationAlwaysUsageDescription = "This app uses your location always";
 NSLocationWhenInUseUsageDescription = "This app uses your location when in use";
 NSMicrophoneUsageDescription = "This app uses your microphone";
 NSSpeechRecognitionUsageDescription = "This app uses speech recognition";
+NSCameraUsageDescription = "This app uses your camera";

--- a/CaBot/ja.lproj/InfoPlist.strings
+++ b/CaBot/ja.lproj/InfoPlist.strings
@@ -29,3 +29,4 @@ NSLocationAlwaysUsageDescription = "このアプリはあなたの位置を利�
 NSLocationWhenInUseUsageDescription = "このアプリは使用中のみあなたの位置を利用します";
 NSMicrophoneUsageDescription = "このアプリはマイクを使用します";
 NSSpeechRecognitionUsageDescription = "このアプリは音声認識を使用します";
+NSCameraUsageDescription = "このアプリはカメラを使用します";


### PR DESCRIPTION
**内容**
こちらのissueのコメントでも報告しましたがTestflightにアップロードする際に2つのエラーが発生しましたのでその修正と、未来館様Testfligthに合わせたプロファイルの変更が含まれたプルリクエストになります。

**報告したissue**
https://github.com/CMU-cabot/TODO-Consortium/issues/271#issuecomment-2154105314

**発生したエラーと解決方法**
```
Invalid bundle. Because your app supports Multitasking on iPad, you need to include the LaunchScreen launch storyboard file in your CMU.CaBotRemote.CaBot.Test bundle. Use UILaunchScreen instead if the app’s MinimumOSVersion is 14 or higher and you prefer to configure the launch screen without storyboards. For details, see: https://developer.apple.com/documentation/bundleresources/information_property_list/uilaunchstoryboardname (ID: dbe906df-c42d-4591-b72b-c273317549c2)
```
CaBot/Info.plistにUILaunchScreenKeyを追加いたしました。

```
ITMS-90683: Missing purpose string in Info.plist - Your app’s code references one or more APIs that access sensitive user data, or the app has one or more entitlements that permit such access. The Info.plist file for the “CaBot.app” bundle should contain a NSCameraUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. If you’re using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. For details, visit: https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/requesting_access_to_protected_resources.
```
CaBot/Info.plist、CaBot/en.lproj/InfoPlist.strings、CaBot/ja.lproj/InfoPlist.stringsにNSCameraUsageDescriptionKeyを追加いたしました。

ご確認よろしくお願いいたします。