### PR TITLE
fix testflight issue

### DIFF
--- a/CaBot.xcodeproj/project.pbxproj
+++ b/CaBot.xcodeproj/project.pbxproj
@@ -989,9 +989,11 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1008,9 +1010,10 @@
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "\"-DATTEND\"";
-				PRODUCT_BUNDLE_IDENTIFIER = "CMU.CaBotRemote.CaBot-User";
+				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Attendant;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot Attendant Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -1024,9 +1027,11 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1043,9 +1048,10 @@
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "\"-DATTEND\"";
-				PRODUCT_BUNDLE_IDENTIFIER = "CMU.CaBotRemote.CaBot-User";
+				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Attendant;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot Attendant Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -1173,9 +1179,11 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1192,9 +1200,10 @@
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "\"-DUSER\"";
-				PRODUCT_BUNDLE_IDENTIFIER = "CMU.CaBotRemote.CaBot-Attend";
+				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.User;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot User Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -1208,9 +1217,11 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1227,9 +1238,10 @@
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "\"-DUSER\"";
-				PRODUCT_BUNDLE_IDENTIFIER = "CMU.CaBotRemote.CaBot-Attend";
+				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.User;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot User Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;

--- a/CaBot.xcodeproj/project.pbxproj
+++ b/CaBot.xcodeproj/project.pbxproj
@@ -989,11 +989,9 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1013,7 +1011,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Attendant;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot Attendant Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -1027,11 +1024,9 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1051,7 +1046,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.Attendant;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot Attendant Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -1179,11 +1173,9 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1203,7 +1195,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.User;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot User Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
@@ -1217,11 +1208,9 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"CaBot/Views/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = H84S8WFTWG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1241,7 +1230,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = CMU.CaBotRemote.CaBot.User;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CaBot User Test Development";
 				SWIFT_OBJC_BRIDGING_HEADER = CaBot/bridging.h;
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;

--- a/CaBot/Info.plist
+++ b/CaBot/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1</string>
+	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -39,6 +39,8 @@
 	<string>This app uses your microphone</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>This app uses speech recognition</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This app uses your camera</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
@@ -47,6 +49,18 @@
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchImage</key>
+		<dict>
+			<key>UILaunchImageMinimumOSVersion</key>
+			<string>14.0</string>
+			<key>UILaunchImageName</key>
+			<string>LaunchImage</string>
+		</dict>
+		<key>UILaunchScreenBackgroundColor</key>
+		<string>UIColor.systemBackgroundColor</string>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/CaBot/en.lproj/Attend-InfoPlist.strings
+++ b/CaBot/en.lproj/Attend-InfoPlist.strings
@@ -29,3 +29,4 @@ NSLocationAlwaysUsageDescription = "This app uses your location always";
 NSLocationWhenInUseUsageDescription = "This app uses your location when in use";
 NSMicrophoneUsageDescription = "This app uses your microphone";
 NSSpeechRecognitionUsageDescription = "This app uses speech recognition";
+NSCameraUsageDescription = "This app uses your camera";

--- a/CaBot/en.lproj/User-InfoPlist.strings
+++ b/CaBot/en.lproj/User-InfoPlist.strings
@@ -29,3 +29,4 @@ NSLocationAlwaysUsageDescription = "This app uses your location always";
 NSLocationWhenInUseUsageDescription = "This app uses your location when in use";
 NSMicrophoneUsageDescription = "This app uses your microphone";
 NSSpeechRecognitionUsageDescription = "This app uses speech recognition";
+NSCameraUsageDescription = "This app uses your camera";

--- a/CaBot/ja.lproj/Attend-InfoPlist.strings
+++ b/CaBot/ja.lproj/Attend-InfoPlist.strings
@@ -29,3 +29,4 @@ NSLocationAlwaysUsageDescription = "このアプリはあなたの位置を利�
 NSLocationWhenInUseUsageDescription = "このアプリは使用中のみあなたの位置を利用します";
 NSMicrophoneUsageDescription = "このアプリはマイクを使用します";
 NSSpeechRecognitionUsageDescription = "このアプリは音声認識を使用します";
+NSCameraUsageDescription = "このアプリはカメラを使用します";

--- a/CaBot/ja.lproj/User-InfoPlist.strings
+++ b/CaBot/ja.lproj/User-InfoPlist.strings
@@ -29,3 +29,4 @@ NSLocationAlwaysUsageDescription = "このアプリはあなたの位置を利�
 NSLocationWhenInUseUsageDescription = "このアプリは使用中のみあなたの位置を利用します";
 NSMicrophoneUsageDescription = "このアプリはマイクを使用します";
 NSSpeechRecognitionUsageDescription = "このアプリは音声認識を使用します";
+NSCameraUsageDescription = "このアプリはカメラを使用します";


### PR DESCRIPTION
**内容**
こちらのissueのコメントでも報告しましたがTestflightにアップロードする際に2つのエラーが発生しましたのでその修正と、未来館様Testfligthに合わせたプロファイルの変更が含まれたプルリクエストになります。

**報告したissue**
https://github.com/CMU-cabot/TODO-Consortium/issues/271#issuecomment-2154105314

**発生したエラーと解決方法**
```
Invalid bundle. Because your app supports Multitasking on iPad, you need to include the LaunchScreen launch storyboard file in your CMU.CaBotRemote.CaBot.Test bundle. Use UILaunchScreen instead if the app’s MinimumOSVersion is 14 or higher and you prefer to configure the launch screen without storyboards. For details, see: https://developer.apple.com/documentation/bundleresources/information_property_list/uilaunchstoryboardname (ID: dbe906df-c42d-4591-b72b-c273317549c2)
```
CaBot/Info.plistにUILaunchScreenKeyを追加いたしました。

```
ITMS-90683: Missing purpose string in Info.plist - Your app’s code references one or more APIs that access sensitive user data, or the app has one or more entitlements that permit such access. The Info.plist file for the “CaBot.app” bundle should contain a NSCameraUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. If you’re using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. For details, visit: https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/requesting_access_to_protected_resources.
```
CaBot/Info.plist、CaBot/en.lproj/Attend-InfoPlist.strings、CaBot/en.lproj/User-InfoPlist.strings、CaBot/ja.lproj/Attend-InfoPlist.strings、にNSCameraUsageDescriptionKeyを追加いたしました。

ご確認よろしくお願いいたします。