### PR TITLE
Pq chinka/resource download

### DIFF
--- a/CaBot.xcodeproj/project.pbxproj
+++ b/CaBot.xcodeproj/project.pbxproj
@@ -112,6 +112,10 @@
 		D7CC05382BFB688400C0B10A /* User-InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D7CC05362BFB688400C0B10A /* User-InfoPlist.strings */; };
 		D7D7A6FB2BFECB490072ADF6 /* TourDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D7A6FA2BFECB490072ADF6 /* TourDetailView.swift */; };
 		D7E54B522C0CD03A002FE3C4 /* MainMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E54B512C0CD03A002FE3C4 /* MainMenuView.swift */; };
+		E46C82642C18081100917AB3 /* ResourceDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46C82632C18081100917AB3 /* ResourceDownload.swift */; };
+		E46C82652C18081100917AB3 /* ResourceDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46C82632C18081100917AB3 /* ResourceDownload.swift */; };
+		E493D8792C2279F700691097 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = E493D8782C2279F700691097 /* ZIPFoundation */; };
+		E493D87B2C227A0D00691097 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = E493D87A2C227A0D00691097 /* ZIPFoundation */; };
 		E561455F2A6E02A8005CF82F /* RosWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E561455E2A6E02A8005CF82F /* RosWebView.swift */; };
 /* End PBXBuildFile section */
 
@@ -219,6 +223,7 @@
 		D7CC05392BFB68BB00C0B10A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = "ja.lproj/User-InfoPlist.strings"; sourceTree = "<group>"; };
 		D7D7A6FA2BFECB490072ADF6 /* TourDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TourDetailView.swift; sourceTree = "<group>"; };
 		D7E54B512C0CD03A002FE3C4 /* MainMenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainMenuView.swift; sourceTree = "<group>"; };
+		E46C82632C18081100917AB3 /* ResourceDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownload.swift; sourceTree = "<group>"; };
 		E561455E2A6E02A8005CF82F /* RosWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosWebView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -233,6 +238,7 @@
 				308FCE2A27E12844009FCC7B /* Gzip in Frameworks */,
 				0967677F29371BA0005CFA58 /* SocketIO in Frameworks */,
 				3009AC3126AA3F4000370873 /* HLPDialog in Frameworks */,
+				E493D87B2C227A0D00691097 /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -269,6 +275,7 @@
 				D7CC051E2BFB352700C0B10A /* Gzip in Frameworks */,
 				D7CC051F2BFB352700C0B10A /* SocketIO in Frameworks */,
 				D7CC05202BFB352700C0B10A /* HLPDialog in Frameworks */,
+				E493D8792C2279F700691097 /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -366,6 +373,7 @@
 				30E99DA3266B2216001ACAAA /* BeaconSampler.swift */,
 				30E50DCB269F672800729ABD /* TourManager.swift */,
 				3096BF1726A5D0990066F256 /* TTSHelper.swift */,
+				E46C82632C18081100917AB3 /* ResourceDownload.swift */,
 			);
 			path = CaBot;
 			sourceTree = "<group>";
@@ -470,6 +478,7 @@
 				308FCE2927E12844009FCC7B /* Gzip */,
 				0967677E29371BA0005CFA58 /* SocketIO */,
 				306069B329A5E45D001FB5DB /* NavigationBackport */,
+				E493D87A2C227A0D00691097 /* ZIPFoundation */,
 			);
 			productName = CaBot;
 			productReference = 7E29F009228B548100CA7DD6 /* CaBot-Attend.app */;
@@ -540,6 +549,7 @@
 				D7CC051A2BFB352700C0B10A /* Frameworks */,
 				D7CC05212BFB352700C0B10A /* ShellScript */,
 				D7CC05222BFB352700C0B10A /* Resources */,
+				E46C82662C182BB200917AB3 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -553,6 +563,7 @@
 				D7CC04ED2BFB352700C0B10A /* Gzip */,
 				D7CC04EF2BFB352700C0B10A /* SocketIO */,
 				D7CC04F12BFB352700C0B10A /* NavigationBackport */,
+				E493D8782C2279F700691097 /* ZIPFoundation */,
 			);
 			productName = CaBot;
 			productReference = D7CC052B2BFB352700C0B10A /* CaBot-User.app */;
@@ -603,6 +614,7 @@
 				0967677D29371B9F005CFA58 /* XCRemoteSwiftPackageReference "socket" */,
 				306069B229A5E45D001FB5DB /* XCRemoteSwiftPackageReference "NavigationBackport" */,
 				7EDE7C9229B5733D00A65829 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
+				E493D8772C2279B200691097 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			productRefGroup = 7E29F00A228B548100CA7DD6 /* Products */;
 			projectDirPath = "";
@@ -677,6 +689,23 @@
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nTHREE_JS=${TEMP_DIR}/three.min.js\ncurl -o $THREE_JS https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js\ncp -f $THREE_JS ${SRCROOT}/Resource/localserver/js/\n\nEVENTEMITTER2_JS=${TEMP_DIR}/eventemitter2.min.js\ncurl -o $EVENTEMITTER2_JS https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.min.js\ncp -f $EVENTEMITTER2_JS ${SRCROOT}/Resource/localserver/js/\n\nROSLIB_JS=${TEMP_DIR}/roslib.js\ncurl -o $ROSLIB_JS https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js\ncp -f $ROSLIB_JS ${SRCROOT}/Resource/localserver/js/\n\nROS3D_JS=${TEMP_DIR}/ros3d.min.js\ncurl -o $ROS3D_JS https://raw.githubusercontent.com/CMU-cabot/ros3djs/cabot-ros2/build/ros3d.min.js\ncp -f $ROS3D_JS ${SRCROOT}/Resource/localserver/js/\n\nfor lang in en.lproj ja.lproj; do\n    mkdir -p \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/${lang}\"\n    cp \"${SRCROOT}/CaBot/${lang}/User-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/${lang}/InfoPlist.strings\"\ndone\n";
 		};
+		E46C82662C182BB200917AB3 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n";
+		};
 		E5FD56542A835D56008237DC /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -725,6 +754,7 @@
 				E561455F2A6E02A8005CF82F /* RosWebView.swift in Sources */,
 				30E50DD8269F784A00729ABD /* MainMenuView.swift in Sources */,
 				7EDF3C4229D4776D00AD1115 /* I18NExtension.swift in Sources */,
+				E46C82642C18081100917AB3 /* ResourceDownload.swift in Sources */,
 				3096BF1826A5D0990066F256 /* TTSHelper.swift in Sources */,
 				308FCE1D27D8F4D3009FCC7B /* SystemStatusView.swift in Sources */,
 				30E50DDB269F7E3800729ABD /* CaBot.xcdatamodeld in Sources */,
@@ -792,6 +822,7 @@
 				D7CC05052BFB352700C0B10A /* RootView.swift in Sources */,
 				D7CC05062BFB352700C0B10A /* NavUtil.m in Sources */,
 				D7CC05072BFB352700C0B10A /* ConversationView.swift in Sources */,
+				E46C82652C18081100917AB3 /* ResourceDownload.swift in Sources */,
 				D7D7A6FB2BFECB490072ADF6 /* TourDetailView.swift in Sources */,
 				D7CC05082BFB352700C0B10A /* SettingView.swift in Sources */,
 				D7CC05092BFB352700C0B10A /* RosWebView.swift in Sources */,
@@ -1401,6 +1432,14 @@
 				version = 0.7.1;
 			};
 		};
+		E493D8772C2279B200691097 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/weichsel/ZIPFoundation.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.19;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1473,6 +1512,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D7CC04F22BFB352700C0B10A /* XCRemoteSwiftPackageReference "NavigationBackport" */;
 			productName = NavigationBackport;
+		};
+		E493D8782C2279F700691097 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E493D8772C2279B200691097 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
+		};
+		E493D87A2C227A0D00691097 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E493D8772C2279B200691097 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/CaBot/Base.lproj/Localizable.strings
+++ b/CaBot/Base.lproj/Localizable.strings
@@ -296,7 +296,7 @@
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
 
 //Resource Download Alert View
-"RetryAlert" = "Check the connection with the server！";
+"RetryAlert" = "Check the connection with the server!";
 "Retry" = "Retry";
 "ReturnMainmenu" = "ReturnMainMenu";
 "ResourceDownload" = "Resource Download";

--- a/CaBot/Base.lproj/Localizable.strings
+++ b/CaBot/Base.lproj/Localizable.strings
@@ -294,3 +294,7 @@
 "Restart Localization"="Restart Localization";
 "Restarting Localization"="Restarting Localization";
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
+
+//Resource Download Alert View
+"RetryAlert" = "Check the connection with the server,Please！";
+"Retry" = "Retry";

--- a/CaBot/Base.lproj/Localizable.strings
+++ b/CaBot/Base.lproj/Localizable.strings
@@ -296,6 +296,7 @@
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
 
 //Resource Download Alert View
-"RetryAlert" = "Check the connection with the server,Please！";
+"RetryAlert" = "Check the connection with the server！";
 "Retry" = "Retry";
 "ReturnMainmenu" = "ReturnMainMenu";
+"ResourceDownload" = "Resource Download";

--- a/CaBot/Base.lproj/Localizable.strings
+++ b/CaBot/Base.lproj/Localizable.strings
@@ -298,3 +298,4 @@
 //Resource Download Alert View
 "RetryAlert" = "Check the connection with the server,Please！";
 "Retry" = "Retry";
+"ReturnMainmenu" = "ReturnMainMenu";

--- a/CaBot/Base.lproj/Localizable.strings
+++ b/CaBot/Base.lproj/Localizable.strings
@@ -296,7 +296,7 @@
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
 
 //Resource Download Alert View
-"RetryAlert" = "Check the connection with the server!";
+"Retry Alert" = "Check the connection with the server!";
 "Retry" = "Retry";
-"ReturnMainmenu" = "ReturnMainMenu";
-"ResourceDownload" = "Resource Download";
+"Return Mainmenu" = "Return MainMenu";
+"Resource Download" = "Resource Download";

--- a/CaBot/CaBotApp.swift
+++ b/CaBot/CaBotApp.swift
@@ -49,6 +49,7 @@ struct CaBotApp: App {
         WindowGroup {
             RootView()
                 .environmentObject(modelData)
+                .environment(\.locale, modelData.resource?.locale ?? .current)
         }.onChange(of: scenePhase) { newScenePhase in
 
             modelData.onChange(of: newScenePhase)

--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -313,10 +313,10 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
             {
             if authRequestedByUser {
                 withAnimation() {
-                    self.displayedScene = .ResourceSelect
+                    self.displayedScene = .App
                 }
             } else {
-                self.displayedScene = .ResourceSelect
+                self.displayedScene = .App
             }
         }
         if self.displayedScene == .ResourceSelect {

--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -484,6 +484,7 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
     @Published var batteryStatus: BatteryStatus = BatteryStatus()
     @Published var touchStatus: TouchStatus = TouchStatus()
     @Published var userInfo: UserInfoBuffer = UserInfoBuffer()
+    @Published var resourceDownload: ResourceDownload
 
     private var addressCandidate: AddressCandidate
     private var bleService: CaBotServiceBLE
@@ -526,6 +527,7 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
         self.tourManager = TourManager(setting: self.detailSettingModel)
         self.dialogViewHelper = DialogViewHelper()
         self.locationManager =  CLLocationManager()
+        self.resourceDownload = ResourceDownload()
 
         // initialize connection type
         var connectionType: ConnectionType = .BLE
@@ -545,9 +547,6 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
         self.tts.delegate = self
         self.logList.delegate = self
 
-        if let selectedIdentifier = UserDefaults.standard.value(forKey: selectedResourceKey) as? String {
-            self.resource = resourceManager.resource(by: selectedIdentifier)
-        }
         if let selectedLang = UserDefaults.standard.value(forKey: selectedResourceLangKey) as? String {
             self.resource?.lang = selectedLang
             self.updateVoice()

--- a/CaBot/ResourceDownload.swift
+++ b/CaBot/ResourceDownload.swift
@@ -1,0 +1,371 @@
+/*******************************************************************************
+ * Copyright (c) 2021  Carnegie Mellon University
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *******************************************************************************/
+
+import UIKit
+import Foundation
+import CommonCrypto
+import ZIPFoundation
+import SwiftUI
+
+//ドキュメントディレクトリ取得
+func getDocumentsDirectory() -> URL{
+    let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+    return paths
+}
+
+//アプリ内にHashファイルが存在しないので、初回保存
+func saveHashTextFile(fileName:String,content:String)
+{
+    let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
+    
+    //ファイルの存在をチェック
+    if FileManager.default.fileExists(atPath: fileURL.path)
+    {
+        //何もしない
+    }else{//ファイルが存在しない場合、新規作成
+        do{
+            try content.write(to:fileURL, atomically: true, encoding: .utf8)
+            print("Hashファイルの保存が完了しました:\(fileURL.path)")
+        }catch{
+            print("Hashファイルの保存が失敗しました:\(error.localizedDescription)")
+        }
+    }
+}
+
+//リトライの際に、ハッシュファイルを削除する
+func deleteHashFile()
+{
+    let hashFileName = "hashFile.txt"//アプリ内に保存するHashファイル名前
+    let hashFileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
+    //すでにファイルが存在する場合は削除
+    if FileManager.default.fileExists(atPath: hashFileURL.path) {
+        do{
+            print("Hashファイルの削除が完了しました:\(hashFileURL.path)")
+            try FileManager.default.removeItem(at: hashFileURL)
+        }catch
+        {
+            print("Hashファイルの削除が失敗しました:\(error.localizedDescription)")
+        }
+      
+   }
+    let resourceFileName = "app-resource"//アプリ内に保存するリソースファイル名前
+    let resourceFileURL = getDocumentsDirectory().appendingPathComponent(resourceFileName)
+    
+    if FileManager.default.fileExists(atPath: resourceFileURL.path) {
+        do{
+            print("リソースファイルの削除が完了しました:\(resourceFileURL.path)")
+            try FileManager.default.removeItem(at: resourceFileURL)
+        }catch
+        {
+            print("リソースファイルの削除が失敗しました:\(error.localizedDescription)")
+        }
+      
+   }
+}
+
+//アプリ内に既存Hashテキストファイルに上書き
+func overwriteHashTextFile(fileName:String,content:String)
+{
+    let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
+    
+    //ファイルの存在をチェック
+    if FileManager.default.fileExists(atPath: fileURL.path)
+    {
+        do{
+            try content.write(to:fileURL, atomically: true, encoding: .utf8)
+            print("Hashファイルの上書きが完了しました:\(fileURL.path)")
+        }catch{
+            print("Hashファイルの上書きが失敗しました:\(error.localizedDescription)")
+        }
+            
+    }else{//ファイルが存在しない場合、新規作成
+     
+    }
+}
+
+
+
+//ZIPリソースファイルを解凍する処理
+func unzipFile(at sourceURL:URL,to destinaltionURL:URL)
+{
+    let fileManager = FileManager()
+    let unzipFileName = "app-resource"//リソースファイル名
+    let unzipedFilePath = destinaltionURL.appendingPathComponent(unzipFileName)//解凍したリソースファイルURL
+    do{
+        //以前に解凍したファイルが存在する場合は削除
+        if FileManager.default.fileExists(atPath: unzipedFilePath.path) {
+           try FileManager.default.removeItem(at: unzipedFilePath)
+            print("既存の解凍したファイルが削除しました\(unzipedFilePath)")
+            
+       }
+        
+        //解凍処理
+        try fileManager.createDirectory(at: destinaltionURL, withIntermediateDirectories: true,attributes:nil)
+        try fileManager.unzipItem(at: sourceURL, to: destinaltionURL)
+        print("解凍が完了しました！\(destinaltionURL)")
+       
+        
+        //解凍した後ZIPファイルが存在する場合は削除
+        if FileManager.default.fileExists(atPath: sourceURL.path) {
+           try FileManager.default.removeItem(at: sourceURL)
+            print("解凍した後ZIPファイルが削除しました")
+       }
+       
+    }catch{
+        
+        print("解凍中にエラーが発生しました！")
+    }
+    
+}
+
+//リソースダウンロード
+ class ResourceDownload{
+    
+    var downloadSuccessed = false//Downloadが成功かどうか
+    var downloadFailed:Bool = false//Downloadが失敗かどうか
+    var isTryFirstDownloaded:Bool = false//初回目のDownload
+    var isStartSpeak:Bool = false//読み上げが始まるか
+     
+    // アプリ開始の際にファイルダウンロードのメソッドを呼び出す
+    public func startFileDownload() {
+        
+        _ = CaBotAppModel()
+        //self.downloadResult = true
+        let hashFileName = "hashFile.txt"//アプリ内に保存するHashファイル名前
+       
+        // ハッシュファイルのダウンロードと解析
+        downloadHashFile() { result in
+            switch result {
+            case .success(let data):
+                var hashValue = ""//hash値
+                //Hash値取得のため、変換処理
+                if let content = String(data: data, encoding: .utf8) {
+                    let lines = content.split(separator: "\n")
+                    for line in lines {
+                        let components = line.split(separator: " ")
+                        if components.count == 1
+                        {
+                            //Hash値が取得できました
+                            hashValue = String(components[0])
+                            //アプリのDocumentディレクトリ取得
+                            let fileURL=getDocumentsDirectory().appendingPathComponent(hashFileName)
+                            //アプリ内にHashファイルが存在している場合（アプリを二回目で起動する場合）
+                            if FileManager.default.fileExists(atPath: fileURL.path)
+                            {
+                                if let hashFileContent = self.readHashTextFile(fileName: hashFileName ){
+                                        
+                                    print("File content:\(hashFileContent)")
+                                    //アプリ内に既存Hash値がサーバーから取得したHash値と同じ
+                                    if hashFileContent == hashValue
+                                    {
+                                        self.downloadFailed = false
+                                        print("MD5ハッシュが一致しました: \(fileURL)")
+                                        //Hashファイルが保存しない
+                                        }else{//アプリ内に既存Hash値がサーバーから取得したHash値と違う場合
+                                            print("MD5ハッシュが一致しません: \(fileURL.lastPathComponent)")
+                                            //Hashファイルに上書き
+                                            overwriteHashTextFile(fileName: hashFileName, content: hashValue )
+                                            //Zipファイル保存
+                                            self.downloadResourceZipFile()
+                                        }
+                                    }else{
+                                        print("Hash値の取得が失敗しました")
+                                    }
+                                }else{//アプリ内にHashファイルが存在しない場合（アプリを初回目で起動する場合）
+                                    //新しいHashファイル保存
+                                    saveHashTextFile(fileName: hashFileName, content: hashValue)
+                                    //Zipファイル保存
+                                    self.downloadResourceZipFile()
+                                }
+                            }
+                        }//for文　End
+                    }//ハッシュ値取得　End
+                case .failure(let error):
+                    print("ハッシュファイルのダウンロードに失敗しました：\(error)")
+                }
+            }
+    
+    }//startFileDownload end
+    
+    //ハッシュ値取得
+    func downloadHashFile(retries: Int = 3,completion: @escaping (Result<Data, Error>) -> Void) {
+        let appModel = CaBotAppModel()
+        let md5FileURL = URL(string: "http://\(appModel.primaryAddr):9090/map/app-resource-md5")
+        self.isTryFirstDownloaded = true
+        print("ハッシュ値取得開始。\(String(describing: md5FileURL))")
+        let task = URLSession.shared.dataTask(with: md5FileURL!) { (data, response, error) in
+            if !self.downloadSuccessed {
+                if error != nil {
+                    if retries > 0{
+                        print("ダウンロードに失敗しました。リトライを試みます。残りリトライ回数: \(retries)")
+                        deleteHashFile()
+                        self.downloadHashFile( retries: retries - 1, completion: completion)
+                        if retries == 3{//初回リトライの際にエラーメッセージが読み上げ
+                            self.isStartSpeak = true
+                        }
+                    }else{
+                        self.downloadFailed = true
+                        print("AAAダウンロードに失敗しました。アラートUIが表示される:\(self.downloadFailed)")
+                      
+                        //completion(.failure(error))
+                    }
+                  
+                    return
+                }
+            }
+           
+            guard let data = data else {
+                let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
+                completion(.failure(error))
+                return
+            }
+            
+            completion(.success(data))
+        }
+        task.resume()
+    }
+    
+    //アプリ内のHashテキストファイルを読み取る
+    func readHashTextFile(fileName:String) -> String?{
+        
+        let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
+        do{
+            let content = try String(contentsOf:fileURL,encoding: .utf8)
+            print("Hashファイルが読み取りました")
+            self.downloadSuccessed = true
+            self.downloadFailed = false
+            return content
+            
+        }catch{
+            print("Hashファイルの読み取りが失敗しました:\(error.localizedDescription)")
+            return nil
+        }
+    }
+    
+    //リソースZIPファイルをダウンロードする
+    public func downloadResourceZipFile()
+    {
+        let appModel = CaBotAppModel()
+        ///以下はZipファイルダウンロード処理
+        ///zipファイルのURL
+        //let path = "http://localhost:9090/map/app-resource.zip"
+        let path = "http://\(appModel.primaryAddr):9090/map/app-resource.zip"
+        
+        // DownloadのフォルダURLを指定
+        let downloadURL = URL(string: (path))!
+        // 保存先のフォルダURLを指定（ここではドキュメントディレクトリ内の "Downloads" フォルダを作成）
+        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+       // let savedFolderURL = documentsURL.appendingPathComponent("Downloads")
+        self.downloadZipFileFile(from: downloadURL,to:documentsURL) { result in
+            switch result {
+            case .success(let savedURL):
+                unzipFile(at: savedURL, to: documentsURL)
+                self.downloadFailed = false
+                
+                print("Zipファイルの保存が完了しました: \(savedURL)")
+            case .failure(let error):
+                print("Zipファイルの保存に失敗しました: \(error)")
+            }
+        }
+    }
+    
+    
+    
+    
+    func downloadZipFileFile(from url: URL, to destinationFolderURL: URL,retries:Int = 3, completion: @escaping (Result<URL, Error>) -> Void) {
+           let task = URLSession.shared.downloadTask(with: url) { (localURL, response, error) in
+              /* if let error = error {
+                   if retries > 0{
+                       print("ダウンロードに失敗しました。リトライを試みます。残りリトライ回数: \(retries)")
+                       //self.downloadFile(from: url, to: destinationFolderURL,retries:retries - 1, completion: completion)
+                   }else{
+                       self.isTryFirstDownloaded = true
+                       self.downloadFailed = true
+                       completion(.failure(error))
+                   }
+                   
+                   return
+               }*/
+               
+               guard let localURL = localURL else {
+                   let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "File URL is nil"])
+                   completion(.failure(error))
+                   return
+               }
+               
+               do {
+                   let destinationURL = destinationFolderURL.appendingPathComponent(url.lastPathComponent)
+                   
+                    //すでにファイルが存在する場合は削除
+                    if FileManager.default.fileExists(atPath: destinationURL.path) {
+                       try FileManager.default.removeItem(at: destinationURL)
+                   }
+                   
+                   // ダウンロードしたファイルを指定のフォルダに移動
+                   try FileManager.default.moveItem(at: localURL, to: destinationURL)
+                   completion(.success(destinationURL))
+               } catch {
+                   completion(.failure(error))
+               }
+           }
+           task.resume()
+       }
+    
+}//Class Resource End
+
+
+
+//リソースダウンロード失敗際にエラーメッセージとリトライボタン表示
+struct ResourceDownloadRetryUIView :View {
+    @EnvironmentObject var modelData: CaBotAppModel
+    @State public var isDownloadFinished = false
+    @State var resourceDownload = ResourceDownload()
+    var body: some View {
+        //初回目Donwload。1回のみ実行
+        if !resourceDownload.isTryFirstDownloaded
+        {
+            let _: () = resourceDownload.startFileDownload()
+        }
+        //Downloadが失敗したら、エラーメッセージとリトライが表示する
+        if resourceDownload.downloadFailed
+        {
+            //エラ〜メッセージが読み上げ
+            if resourceDownload.isStartSpeak
+            {
+                let _ =  print("エラ〜メッセージが読み上げ: \(resourceDownload.isStartSpeak)")
+                let message = CustomLocalizedString("RetryAlert", lang: modelData.resourceLang)
+                let _ = modelData.speak(message) {}
+                   
+                let _ = resourceDownload.isStartSpeak = false
+            }
+            
+            Section(header:  Text("RetryAlert").font(.caption2).foregroundColor(.red).lineLimit(1)){
+                Button(action: {
+                    let _: () = resourceDownload.startFileDownload()
+                    
+                },label: {
+                    Text("Retry").foregroundColor(.blue)
+                })
+            }
+        }
+    }
+}

--- a/CaBot/ResourceDownload.swift
+++ b/CaBot/ResourceDownload.swift
@@ -281,6 +281,7 @@ class ResourceDownload{
                 unzipFile(at: savedURL, to: documentsURL)
                 self.downloadFailed = false
                 
+                appModel.resourceManager.updateResources()
                 print("Zip file saving completed: \(savedURL)")
             case .failure(let error):
                 print("Failed to save zip file: \(error)")

--- a/CaBot/ResourceDownload.swift
+++ b/CaBot/ResourceDownload.swift
@@ -26,213 +26,213 @@ import CommonCrypto
 import ZIPFoundation
 import SwiftUI
 
-//ドキュメントディレクトリ取得
+//Get document directory
 func getDocumentsDirectory() -> URL{
     let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
     return paths
 }
 
-//アプリ内にHashファイルが存在しないので、初回保存
+//Since there is no Hash file in the app, save it for the first time
 func saveHashTextFile(fileName:String,content:String)
 {
     let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
     
-    //ファイルの存在をチェック
+    //Check file existence
     if FileManager.default.fileExists(atPath: fileURL.path)
     {
-        //何もしない
-    }else{//ファイルが存在しない場合、新規作成
+        //do nothing
+    }else{//If the file does not exist, create a new one
         do{
             try content.write(to:fileURL, atomically: true, encoding: .utf8)
-            print("Hashファイルの保存が完了しました:\(fileURL.path)")
+            print("Saving of Hash file is completed:\(fileURL.path)")
         }catch{
-            print("Hashファイルの保存が失敗しました:\(error.localizedDescription)")
+            print("Saving Hash file failed:\(error.localizedDescription)")
         }
     }
 }
 
-//リトライの際に、ハッシュファイルを削除する
+//Delete hash files on retry
 func deleteHashFile()
 {
-    let hashFileName = "hashFile.txt"//アプリ内に保存するHashファイル名前
+    let hashFileName = "hashFile.txt"//Hash file name saved within the app
     let hashFileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
-    //すでにファイルが存在する場合は削除
+    //Delete if file already exists
     if FileManager.default.fileExists(atPath: hashFileURL.path) {
         do{
-            print("Hashファイルの削除が完了しました:\(hashFileURL.path)")
+            print("Hash file deletion completed:\(hashFileURL.path)")
             try FileManager.default.removeItem(at: hashFileURL)
         }catch
         {
-            print("Hashファイルの削除が失敗しました:\(error.localizedDescription)")
+            print("Hash file deletion failed:\(error.localizedDescription)")
         }
-      
-   }
-    let resourceFileName = "app-resource"//アプリ内に保存するリソースファイル名前
+        
+    }
+    let resourceFileName = "app-resource"//Resource file name saved within the app
     let resourceFileURL = getDocumentsDirectory().appendingPathComponent(resourceFileName)
     
     if FileManager.default.fileExists(atPath: resourceFileURL.path) {
         do{
-            print("リソースファイルの削除が完了しました:\(resourceFileURL.path)")
+            print("Resource file deletion completed:\(resourceFileURL.path)")
             try FileManager.default.removeItem(at: resourceFileURL)
         }catch
         {
-            print("リソースファイルの削除が失敗しました:\(error.localizedDescription)")
+            print("Resource file deletion failed:\(error.localizedDescription)")
         }
-      
-   }
+        
+    }
 }
 
-//アプリ内に既存Hashテキストファイルに上書き
+//Overwrite the existing Hash text file in the app
 func overwriteHashTextFile(fileName:String,content:String)
 {
     let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
     
-    //ファイルの存在をチェック
+    //Check file existence
     if FileManager.default.fileExists(atPath: fileURL.path)
     {
         do{
             try content.write(to:fileURL, atomically: true, encoding: .utf8)
-            print("Hashファイルの上書きが完了しました:\(fileURL.path)")
+            print("Hash file overwriting completed:\(fileURL.path)")
         }catch{
-            print("Hashファイルの上書きが失敗しました:\(error.localizedDescription)")
+            print("Hash file overwriting failed:\(error.localizedDescription)")
         }
-            
-    }else{//ファイルが存在しない場合、新規作成
-     
+        
+    }else{
+        
     }
 }
 
 
 
-//ZIPリソースファイルを解凍する処理
+//Process of unzipping a ZIP resource file
 func unzipFile(at sourceURL:URL,to destinaltionURL:URL)
 {
     let fileManager = FileManager()
-    let unzipFileName = "app-resource"//リソースファイル名
-    let unzipedFilePath = destinaltionURL.appendingPathComponent(unzipFileName)//解凍したリソースファイルURL
+    let unzipFileName = "app-resource"//resource file name
+    let unzipedFilePath = destinaltionURL.appendingPathComponent(unzipFileName)//Unzipped resource file URL
     do{
-        //以前に解凍したファイルが存在する場合は削除
+        //Delete previously unzipped files if they exist
         if FileManager.default.fileExists(atPath: unzipedFilePath.path) {
-           try FileManager.default.removeItem(at: unzipedFilePath)
-            print("既存の解凍したファイルが削除しました\(unzipedFilePath)")
+            try FileManager.default.removeItem(at: unzipedFilePath)
+            print("Existing unzipped files deleted\(unzipedFilePath)")
             
-       }
+        }
         
-        //解凍処理
+        //Thawing process
         try fileManager.createDirectory(at: destinaltionURL, withIntermediateDirectories: true,attributes:nil)
         try fileManager.unzipItem(at: sourceURL, to: destinaltionURL)
-        print("解凍が完了しました！\(destinaltionURL)")
-       
+        print("Unzipping completed！\(destinaltionURL)")
         
-        //解凍した後ZIPファイルが存在する場合は削除
+        
+        //Delete the ZIP file if it exists after unzipping it
         if FileManager.default.fileExists(atPath: sourceURL.path) {
-           try FileManager.default.removeItem(at: sourceURL)
-            print("解凍した後ZIPファイルが削除しました")
-       }
-       
+            try FileManager.default.removeItem(at: sourceURL)
+            print("ZIP file deleted after unzipping")
+        }
+        
     }catch{
         
-        print("解凍中にエラーが発生しました！")
+        print("An error occurred while unzipping！")
     }
     
 }
 
-//リソースダウンロード
- class ResourceDownload{
+//resource download
+class ResourceDownload{
     
-    var downloadSuccessed = false//Downloadが成功かどうか
-    var downloadFailed:Bool = false//Downloadが失敗かどうか
-    var isTryFirstDownloaded:Bool = false//初回目のDownload
-    var isStartSpeak:Bool = false//読み上げが始まるか
-     
-    // アプリ開始の際にファイルダウンロードのメソッドを呼び出す
+    var downloadSuccessed = false//Whether the download was successful or not
+    var downloadFailed:Bool = false//Whether the download failed
+    var isTryFirstDownloaded:Bool = false//First download
+    var isStartSpeak:Bool = false//Will reading begin?
+    
+    // Call the file download method when the app starts
     public func startFileDownload() {
         
         _ = CaBotAppModel()
         //self.downloadResult = true
-        let hashFileName = "hashFile.txt"//アプリ内に保存するHashファイル名前
-       
-        // ハッシュファイルのダウンロードと解析
+        let hashFileName = "hashFile.txt"//Hash file name saved within the app
+        
+        // Downloading and parsing hash files
         downloadHashFile() { result in
             switch result {
             case .success(let data):
-                var hashValue = ""//hash値
-                //Hash値取得のため、変換処理
+                var hashValue = ""//hash Value
+                //Conversion processing to obtain Hash value
                 if let content = String(data: data, encoding: .utf8) {
                     let lines = content.split(separator: "\n")
                     for line in lines {
                         let components = line.split(separator: " ")
                         if components.count == 1
                         {
-                            //Hash値が取得できました
+                            //I was able to get the Hash value
                             hashValue = String(components[0])
-                            //アプリのDocumentディレクトリ取得
+                            //Get the app's Document directory
                             let fileURL=getDocumentsDirectory().appendingPathComponent(hashFileName)
-                            //アプリ内にHashファイルが存在している場合（アプリを二回目で起動する場合）
+                            //If a Hash file exists within the app (when starting the app for the second time)
                             if FileManager.default.fileExists(atPath: fileURL.path)
                             {
                                 if let hashFileContent = self.readHashTextFile(fileName: hashFileName ){
-                                        
+                                    
                                     print("File content:\(hashFileContent)")
-                                    //アプリ内に既存Hash値がサーバーから取得したHash値と同じ
+                                    //The existing Hash value in the app is the same as the Hash value obtained from the server
                                     if hashFileContent == hashValue
                                     {
                                         self.downloadFailed = false
-                                        print("MD5ハッシュが一致しました: \(fileURL)")
-                                        //Hashファイルが保存しない
-                                        }else{//アプリ内に既存Hash値がサーバーから取得したHash値と違う場合
-                                            print("MD5ハッシュが一致しません: \(fileURL.lastPathComponent)")
-                                            //Hashファイルに上書き
-                                            overwriteHashTextFile(fileName: hashFileName, content: hashValue )
-                                            //Zipファイル保存
-                                            self.downloadResourceZipFile()
-                                        }
-                                    }else{
-                                        print("Hash値の取得が失敗しました")
+                                        print("MD5 hash matched: \(fileURL)")
+                                        //Hash File won't save
+                                    }else{//If the existing Hash value in the app is different from the Hash value obtained from the server
+                                        print("MD5 hashes don't match: \(fileURL.lastPathComponent)")
+                                        //Overwrite Hash file
+                                        overwriteHashTextFile(fileName: hashFileName, content: hashValue )
+                                        //Save zip file
+                                        self.downloadResourceZipFile()
                                     }
-                                }else{//アプリ内にHashファイルが存在しない場合（アプリを初回目で起動する場合）
-                                    //新しいHashファイル保存
-                                    saveHashTextFile(fileName: hashFileName, content: hashValue)
-                                    //Zipファイル保存
-                                    self.downloadResourceZipFile()
+                                }else{
+                                    print("Failed to get Hash value")
                                 }
+                            }else{//If there is no Hash file in the app (when starting the app for the first time)
+                                //Save new Hash file
+                                saveHashTextFile(fileName: hashFileName, content: hashValue)
+                                //Save zip file
+                                self.downloadResourceZipFile()
                             }
-                        }//for文　End
-                    }//ハッシュ値取得　End
-                case .failure(let error):
-                    print("ハッシュファイルのダウンロードに失敗しました：\(error)")
-                }
+                        }
+                    }//for　End
+                }//Get hash value　End
+            case .failure(let error):
+                print("Failed to download hash file：\(error)")
             }
-    
+        }
+        
     }//startFileDownload end
     
-    //ハッシュ値取得
+    //Get hash value
     func downloadHashFile(retries: Int = 3,completion: @escaping (Result<Data, Error>) -> Void) {
         let appModel = CaBotAppModel()
         let md5FileURL = URL(string: "http://\(appModel.primaryAddr):9090/map/app-resource-md5")
         self.isTryFirstDownloaded = true
-        print("ハッシュ値取得開始。\(String(describing: md5FileURL))")
+        print("Start obtaining hash value。\(String(describing: md5FileURL))")
         let task = URLSession.shared.dataTask(with: md5FileURL!) { (data, response, error) in
             if !self.downloadSuccessed {
                 if error != nil {
                     if retries > 0{
-                        print("ダウンロードに失敗しました。リトライを試みます。残りリトライ回数: \(retries)")
+                        print("Download failed. Attempt to retry. Remaining number of retries: \(retries)")
                         deleteHashFile()
                         self.downloadHashFile( retries: retries - 1, completion: completion)
-                        if retries == 3{//初回リトライの際にエラーメッセージが読み上げ
+                        if retries == 3{//An error message is read aloud when retrying for the first time.
                             self.isStartSpeak = true
                         }
                     }else{
                         self.downloadFailed = true
-                        print("AAAダウンロードに失敗しました。アラートUIが表示される:\(self.downloadFailed)")
-                      
+                        print("Download failed. Alert UI is displayed:\(self.downloadFailed)")
+                        
                         //completion(.failure(error))
                     }
-                  
+                    
                     return
                 }
             }
-           
+            
             guard let data = data else {
                 let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
                 completion(.failure(error))
@@ -244,46 +244,46 @@ func unzipFile(at sourceURL:URL,to destinaltionURL:URL)
         task.resume()
     }
     
-    //アプリ内のHashテキストファイルを読み取る
+    //Read Hash text file in app
     func readHashTextFile(fileName:String) -> String?{
         
         let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
         do{
             let content = try String(contentsOf:fileURL,encoding: .utf8)
-            print("Hashファイルが読み取りました")
+            print("Read Hash file")
             self.downloadSuccessed = true
             self.downloadFailed = false
             return content
             
         }catch{
-            print("Hashファイルの読み取りが失敗しました:\(error.localizedDescription)")
+            print("Reading Hash file failed:\(error.localizedDescription)")
             return nil
         }
     }
     
-    //リソースZIPファイルをダウンロードする
+    //Download resource ZIP file
     public func downloadResourceZipFile()
     {
         let appModel = CaBotAppModel()
-        ///以下はZipファイルダウンロード処理
-        ///zipファイルのURL
+        ///Below is the Zip file download process
+        ///zip file URL
         //let path = "http://localhost:9090/map/app-resource.zip"
         let path = "http://\(appModel.primaryAddr):9090/map/app-resource.zip"
         
-        // DownloadのフォルダURLを指定
+        // Specify the Download folder URL
         let downloadURL = URL(string: (path))!
-        // 保存先のフォルダURLを指定（ここではドキュメントディレクトリ内の "Downloads" フォルダを作成）
+        // Specify the destination folder URL (here, create the "Downloads" folder in the document directory)
         let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-       // let savedFolderURL = documentsURL.appendingPathComponent("Downloads")
+        // let savedFolderURL = documentsURL.appendingPathComponent("Downloads")
         self.downloadZipFileFile(from: downloadURL,to:documentsURL) { result in
             switch result {
             case .success(let savedURL):
                 unzipFile(at: savedURL, to: documentsURL)
                 self.downloadFailed = false
                 
-                print("Zipファイルの保存が完了しました: \(savedURL)")
+                print("Zip file saving completed: \(savedURL)")
             case .failure(let error):
-                print("Zipファイルの保存に失敗しました: \(error)")
+                print("Failed to save zip file: \(error)")
             }
         }
     }
@@ -292,73 +292,62 @@ func unzipFile(at sourceURL:URL,to destinaltionURL:URL)
     
     
     func downloadZipFileFile(from url: URL, to destinationFolderURL: URL,retries:Int = 3, completion: @escaping (Result<URL, Error>) -> Void) {
-           let task = URLSession.shared.downloadTask(with: url) { (localURL, response, error) in
-              /* if let error = error {
-                   if retries > 0{
-                       print("ダウンロードに失敗しました。リトライを試みます。残りリトライ回数: \(retries)")
-                       //self.downloadFile(from: url, to: destinationFolderURL,retries:retries - 1, completion: completion)
-                   }else{
-                       self.isTryFirstDownloaded = true
-                       self.downloadFailed = true
-                       completion(.failure(error))
-                   }
-                   
-                   return
-               }*/
-               
-               guard let localURL = localURL else {
-                   let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "File URL is nil"])
-                   completion(.failure(error))
-                   return
-               }
-               
-               do {
-                   let destinationURL = destinationFolderURL.appendingPathComponent(url.lastPathComponent)
-                   
-                    //すでにファイルが存在する場合は削除
-                    if FileManager.default.fileExists(atPath: destinationURL.path) {
-                       try FileManager.default.removeItem(at: destinationURL)
-                   }
-                   
-                   // ダウンロードしたファイルを指定のフォルダに移動
-                   try FileManager.default.moveItem(at: localURL, to: destinationURL)
-                   completion(.success(destinationURL))
-               } catch {
-                   completion(.failure(error))
-               }
-           }
-           task.resume()
-       }
+        let task = URLSession.shared.downloadTask(with: url) { (localURL, response, error) in
+            guard let localURL = localURL else {
+                let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "File URL is nil"])
+                completion(.failure(error))
+                return
+            }
+            
+            do {
+                let destinationURL = destinationFolderURL.appendingPathComponent(url.lastPathComponent)
+                
+                //Delete if file already exists
+                if FileManager.default.fileExists(atPath: destinationURL.path) {
+                    try FileManager.default.removeItem(at: destinationURL)
+                }
+                
+                // Move the downloaded file to the specified folder
+                try FileManager.default.moveItem(at: localURL, to: destinationURL)
+                completion(.success(destinationURL))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+        task.resume()
+    }
     
 }//Class Resource End
 
 
 
-//リソースダウンロード失敗際にエラーメッセージとリトライボタン表示
+//Display error message and retry button when resource download fails
 struct ResourceDownloadRetryUIView :View {
     @EnvironmentObject var modelData: CaBotAppModel
     @State public var isDownloadFinished = false
     @State var resourceDownload = ResourceDownload()
     var body: some View {
-        //初回目Donwload。1回のみ実行
+        //First time Donwload. Run only once
         if !resourceDownload.isTryFirstDownloaded
         {
             let _: () = resourceDownload.startFileDownload()
         }
-        //Downloadが失敗したら、エラーメッセージとリトライが表示する
+        //If ownload fails, an error message and retry will be displayed
         if resourceDownload.downloadFailed
         {
-            //エラ〜メッセージが読み上げ
             if resourceDownload.isStartSpeak
             {
-                let _ =  print("エラ〜メッセージが読み上げ: \(resourceDownload.isStartSpeak)")
+                let _ =  print("Error message read out loud: \(resourceDownload.isStartSpeak)")
                 let message = CustomLocalizedString("RetryAlert", lang: modelData.resourceLang)
                 let _ = modelData.speak(message) {}
-                   
+                
                 let _ = resourceDownload.isStartSpeak = false
             }
             
-            Section(header:  Text(CustomLocalizedString("RetryAlert", lang: modelData.resourceLang)).font(.caption).foregroundColor(.red).lineLimit(1)){
+            Section(header:  Text(CustomLocalizedString("ResourceDownload", lang: modelData.resourceLang))){
+                
+                Text(CustomLocalizedString("RetryAlert", lang: modelData.resourceLang)).font(.body).foregroundColor(.red).lineLimit(1)
+                
                 Button(action: {
                     let _: () = resourceDownload.startFileDownload()
                     

--- a/CaBot/ResourceDownload.swift
+++ b/CaBot/ResourceDownload.swift
@@ -358,12 +358,12 @@ struct ResourceDownloadRetryUIView :View {
                 let _ = resourceDownload.isStartSpeak = false
             }
             
-            Section(header:  Text("RetryAlert").font(.caption2).foregroundColor(.red).lineLimit(1)){
+            Section(header:  Text(CustomLocalizedString("RetryAlert", lang: modelData.resourceLang)).font(.caption).foregroundColor(.red).lineLimit(1)){
                 Button(action: {
                     let _: () = resourceDownload.startFileDownload()
                     
                 },label: {
-                    Text("Retry").foregroundColor(.blue)
+                    Text(CustomLocalizedString("Retry", lang: modelData.resourceLang)).foregroundColor(.blue)
                 })
             }
         }

--- a/CaBot/ResourceDownload.swift
+++ b/CaBot/ResourceDownload.swift
@@ -242,18 +242,17 @@ struct ResourceDownloadRetryUIView: View {
         }
         // If download fails, an error message and retry will be displayed
         if modelData.resource == nil {
-            Section(header: Text(CustomLocalizedString("Resource Download", lang: modelData.resourceLang))) {
-                Text(CustomLocalizedString("Retry Alert", lang: modelData.resourceLang))
+            Section(header: Text("Resource Download")) {
+                Text("Retry Alert")
                     .font(.body)
                     .foregroundColor(.red)
                     .lineLimit(1)
                 Button(action: {
-                    let _: () = modelData.resourceDownload.deleteHashKey()
-                    let _: () = modelData.resourceDownload.deleteResourceFile()
-                    let _: () = modelData.resourceDownload.startFileDownload(modelData: modelData)
+                    modelData.resourceDownload.deleteHashKey()
+                    modelData.resourceDownload.deleteResourceFile()
+                    modelData.resourceDownload.startFileDownload(modelData: modelData)
                 }, label: {
-                    Text(CustomLocalizedString("Retry", lang: modelData.resourceLang))
-                        .foregroundColor(.blue)
+                    Text("Retry")
                 })
             }
         }

--- a/CaBot/ResourceDownload.swift
+++ b/CaBot/ResourceDownload.swift
@@ -28,18 +28,18 @@ import SwiftUI
 
 //Get document directory
 func getDocumentsDirectory() -> URL{
-    let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-    return paths
+    guard let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+        fatalError("Could not find the document directory.")
+    }
+    return path
 }
 
 //Since there is no Hash file in the app, save it for the first time
-func saveHashTextFile(fileName:String,content:String)
-{
+func saveHashTextFile(fileName:String,content:String){
     let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
     
     //Check file existence
-    if FileManager.default.fileExists(atPath: fileURL.path)
-    {
+    if FileManager.default.fileExists(atPath: fileURL.path){
         //do nothing
     }else{//If the file does not exist, create a new one
         do{
@@ -51,45 +51,13 @@ func saveHashTextFile(fileName:String,content:String)
     }
 }
 
-//Delete hash files on retry
-func deleteHashFile()
-{
-    let hashFileName = "hashFile.txt"//Hash file name saved within the app
-    let hashFileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
-    //Delete if file already exists
-    if FileManager.default.fileExists(atPath: hashFileURL.path) {
-        do{
-            NSLog("Hash file deletion completed:\(hashFileURL.path)")
-            try FileManager.default.removeItem(at: hashFileURL)
-        }catch
-        {
-            NSLog("Hash file deletion failed:\(error.localizedDescription)")
-        }
-        
-    }
-    let resourceFileName = "app-resource"//Resource file name saved within the app
-    let resourceFileURL = getDocumentsDirectory().appendingPathComponent(resourceFileName)
-    
-    if FileManager.default.fileExists(atPath: resourceFileURL.path) {
-        do{
-            NSLog("Resource file deletion completed:\(resourceFileURL.path)")
-            try FileManager.default.removeItem(at: resourceFileURL)
-        }catch
-        {
-            NSLog("Resource file deletion failed:\(error.localizedDescription)")
-        }
-        
-    }
-}
 
 //Overwrite the existing Hash text file in the app
-func overwriteHashTextFile(fileName:String,content:String)
-{
+func overwriteHashTextFile(fileName:String,content:String){
     let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
     
     //Check file existence
-    if FileManager.default.fileExists(atPath: fileURL.path)
-    {
+    if FileManager.default.fileExists(atPath: fileURL.path){
         do{
             try content.write(to:fileURL, atomically: true, encoding: .utf8)
             NSLog("Hash file overwriting completed:\(fileURL.path)")
@@ -99,93 +67,144 @@ func overwriteHashTextFile(fileName:String,content:String)
         
     }
 }
-
-
+//Check Server
+func checkServerStatus(url: URL, completion: @escaping (Bool) -> Void) {
+    let task = URLSession.shared.dataTask(with: url) { data, response, error in
+        if let error = error {
+            NSLog("Error: \(error)")
+            completion(false)
+            return
+        }
+        
+        if let httpResponse = response as? HTTPURLResponse {
+            if httpResponse.statusCode == 200 {
+                completion(true)
+            } else {
+                NSLog("ServerError: \(httpResponse.statusCode)")
+                completion(false)
+            }
+        } else {
+            NSLog("invalid response")
+            completion(false)
+        }
+    }
+    task.resume()
+}
 
 
 //resource download
-final class ResourceDownload :NSObject, ObservableObject{
-    @StateObject var modelData = CaBotAppModel()
-    @Published var downloadFailed:Bool = false//Whether the download failed
-    var isTryFirstDownloaded:Bool = false//First download
+class ResourceDownload {
+    var isStartDownloadedOnSuitcaseConnected:Bool = true//First download When Suitcase is Connected
+    var isStartDownloadedOnSuitcaseUnconnected:Bool = true//First download When Suitcase is not Connected
     var speakCount : Int = 0
     var m5HashValue:String = ""//hash Value
+    //Download Resources When Suitcase is Connected. call only once when app start.
+    func startDownloadResourceOnSuitcaseConnected(modelData: CaBotAppModel){
+        if isStartDownloadedOnSuitcaseConnected{
+            isStartDownloadedOnSuitcaseConnected = false
+            self.startFileDownload(modelData: modelData)
+        }
+    }
+    //Download Resources When Suitcase is not Connected. call only once when app start.
+    func startDownloadResourceOnSuitcaseUnconnected(modelData: CaBotAppModel){
+        if isStartDownloadedOnSuitcaseUnconnected{
+            isStartDownloadedOnSuitcaseUnconnected = false
+            self.startFileDownload(modelData: modelData)
+        }
+    }
     // Call the file download method when the app starts
-    public func startFileDownload() {
-        //self.downloadResult = true
-        let hashFileName = "hashFile.txt"//Hash file name saved within the app
-        DispatchQueue.main.async{
-            // Downloading and parsing hash files
-            self.downloadHashFile() { result in
-                //
-                switch result {
-                case .success(let data):
-                    
-                    //Conversion processing to obtain Hash value
-                    guard let content = String(data: data, encoding: .utf8) else {
+    public func startFileDownload(modelData: CaBotAppModel) {
+        let hashFileName = "hashFile.txt"
+        self.downloadHashFile(modelData: modelData) { result in
+            switch result {
+            case .success(let data):
+                guard let content = String(data: data, encoding: .utf8) else {
+                    return
+                }
+                let lines = content.split(separator: "\n")
+                for line in lines {
+                    let components = line.split(separator: " ")
+                    guard components.count == 1 else {
+                        NSLog("Component count is not 1")
                         return
                     }
-                    let lines = content.split(separator: "\n")
-                    for line in lines {
-                        let components = line.split(separator: " ")
-                        guard components.count == 1 else{
-                            NSLog("Component count is not 1")
-                            return
-                        }
-                        //I was able to get the Hash value
-                        self.m5HashValue = String(components[0])
-                        //Get the app's Document directory
-                        let fileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
-                        //If a Hash file exists within the app (when starting the app for the second time)
-                        if FileManager.default.fileExists(atPath: fileURL.path)
-                        {
-                            if let hashFileContent = self.readHashTextFile(fileName: hashFileName ){
-                                
-                                NSLog("File content:\(hashFileContent)")
-                                //The existing Hash value in the app is the same as the Hash value obtained from the server
-                                if hashFileContent == self.m5HashValue
-                                {
-                                    self.downloadFailed = false
-                                    NSLog("MD5 hash matched: \(fileURL)")
-                                    
-                                    //Hash File won't save
-                                }else{//If the existing Hash value in the app is different from the Hash value obtained from the server
-                                    NSLog("MD5 hashes don't match: \(fileURL.lastPathComponent)")
-                                    //Overwrite Hash file
-                                    overwriteHashTextFile(fileName: hashFileName, content: self.m5HashValue )
-                                    //Save zip file
-                                    self.downloadResourceZipFile()
+                    self.m5HashValue = String(components[0])
+                    let fileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
+                    if FileManager.default.fileExists(atPath: fileURL.path) {
+                        if let hashFileContent = self.readHashTextFile(fileName: hashFileName) {
+                            NSLog("File content:\(hashFileContent)")
+                            //Hash value is the same
+                            if hashFileContent == self.m5HashValue {
+                                //Determine whether the server can be accessed
+                                if let url = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/app-resource.zip") {
+                                    checkServerStatus(url: url) { isOnline in
+                                        if isOnline {
+                                            DispatchQueue.main.async{
+                                                modelData.resourceManager.updateResources()
+                                                if(modelData.resourceManager.resources.count>0){
+                                                    modelData.resource = modelData.resourceManager.resources[0]
+                                                }
+                                            }
+                                        } else {
+                                            NSLog("The server is down")
+                                        }
+                                    }
                                 }
-                            }else{
-                                NSLog("Failed to get Hash value")
+                                
+                                NSLog("MD5 hash matched: \(self.m5HashValue)")
+                            } else {
+                                NSLog("MD5 hashes don't match: \(self.m5HashValue)")
+                                overwriteHashTextFile(fileName: hashFileName, content: self.m5HashValue)
+                                self.downloadResouceFile(modelData: modelData){ result in
+                                    switch result {
+                                    case .success(let data):
+                                        NSLog("Download succeeded. Data received: \(data)")
+                                    case .failure(let error):
+                                        DispatchQueue.main.async{
+                                            self.speakCount = 0
+                                            self.SpeechErrorMessage(modelData: modelData)
+                                            self.deleteHashFile()
+                                        }
+                                        NSLog("Download failed with error: \(error.localizedDescription)")
+                                    }
+                                }
                             }
-                        }else{//If there is no Hash file in the app (when starting the app for the first time)
-                            //Save new Hash file
-                            saveHashTextFile(fileName: hashFileName, content: self.m5HashValue)
-                            //Save zip file
-                            self.downloadResourceZipFile()
+                        } else {
+                            NSLog("Failed to get Hash value")
                         }
-                        
-                    }//for　End
-                case .failure(let error):
-                    NSLog("Failed to download hash file：\(error)")
+                    } else {
+                        saveHashTextFile(fileName: hashFileName, content: self.m5HashValue)
+                        self.downloadResouceFile(modelData: modelData){ result in
+                            switch result {
+                            case .success(let data):
+                                NSLog("Download succeeded. Data received: \(data)")
+                            case .failure(let error):
+                                DispatchQueue.main.async{
+                                    self.speakCount = 0
+                                    self.SpeechErrorMessage(modelData: modelData)
+                                    self.deleteHashFile()
+                                }
+                                NSLog("Download failed with error: \(error.localizedDescription)")
+                            }
+                        }
+                    }
                 }
+            case .failure(let error):
+                DispatchQueue.main.async{
+                    self.speakCount = 0
+                    self.SpeechErrorMessage(modelData: modelData)
+                    self.deleteHashFile()
+                }
+                NSLog("Failed to download hash file：\(error)")
             }
         }
-        
     }//startFileDownload end
     
     //Get hash value
-    func downloadHashFile(retries: Int = 3,timeout: TimeInterval = 2, completion: @escaping (Result<Data, Error>) -> Void) {
-        //Check primaryAddr is nil
-        guard !modelData.getCurrentAddress().isEmpty else{
-            self.downloadFailed = true
-            return
-        }
-        NSLog("Start obtaining hash value。\(modelData.getCurrentAddress())")
-        if let md5FileURL = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/app-resource-md5")
-        {
-            
+    func downloadHashFile(retries: Int = 3,timeout: TimeInterval = 2,modelData: CaBotAppModel, completion: @escaping (Result<Data, Error>) -> Void) {
+        
+        NSLog("Start obtaining hash value. \(modelData.getCurrentAddress())")
+        if let md5FileURL = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/app-resource-md5"){
             
             // Configure the URLSession with timeout
             let configuration = URLSessionConfiguration.default
@@ -193,16 +212,19 @@ final class ResourceDownload :NSObject, ObservableObject{
             let session = URLSession(configuration: configuration)
             
             let task = session.dataTask(with: md5FileURL) { (data, response, error) in
-                if error != nil {
-                    if retries > 0{
-                        NSLog("Download failed. Attempt to retry. Remaining number of retries: \(retries)")
-                        deleteHashFile()
-                        self.downloadHashFile( retries: retries - 1,timeout: timeout, completion: completion)
+                
+                if let error = error  {
+                    if (error as NSError).code == NSURLErrorCannotConnectToHost {
+                        NSLog("Failed to connect to host: \(md5FileURL). The server might not be running.")
+                        let connectionError = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to connect to host: \(md5FileURL). The server might not be running."])
+                        completion(.failure(connectionError))
                     }else{
-                        self.downloadFailed = true
-                        NSLog("Download failed. Alert UI is displayed:\(self.downloadFailed)")
-                        
-                        //completion(.failure(error))
+                        if retries > 0{
+                            NSLog("Download failed. Attempt to retry. Remaining number of retries: \(retries)")
+                            self.downloadHashFile( retries: retries - 1,timeout: timeout,modelData: modelData, completion: completion)
+                        }else{
+                            completion(.failure(error))
+                        }
                     }
                     
                     return
@@ -210,15 +232,19 @@ final class ResourceDownload :NSObject, ObservableObject{
                 
                 guard let data = data else {
                     let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
-                    completion(.failure(error))
+                    if retries > 0 {
+                        NSLog("No data received. Attempt to retry. Remaining number of retries: \(retries - 1)")
+                        DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                            self.downloadHashFile(retries: retries - 1, timeout: timeout, modelData: modelData, completion: completion)
+                        }
+                    } else {
+                        completion(.failure(error))
+                    }
                     return
                 }
-                self.isTryFirstDownloaded = true
                 completion(.success(data))
             }
             task.resume()
-        }else{
-            self.downloadFailed = true
         }
         
     }
@@ -240,71 +266,71 @@ final class ResourceDownload :NSObject, ObservableObject{
         }
     }
     
-    //Download resource ZIP file
-    public func downloadResourceZipFile()
-    {
-        ///Below is the Zip file download process
+    
+    func downloadResouceFile(retries: Int = 3,timeout: TimeInterval = 2,modelData: CaBotAppModel, completion: @escaping (Result<Data, Error>) -> Void) {
         
-        //Check primaryAddr is nil
-        guard !modelData.getCurrentAddress().isEmpty else{
-            return
-        }
-        ///zip file URL
-        if let downloadURL = URL(string:"http://\(modelData.getCurrentAddress()):9090/map/app-resource.zip")
-        {
-            // Specify the destination folder URL (here, create the "Downloads" folder in the document directory)
-            let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            // let savedFolderURL = documentsURL.appendingPathComponent("Downloads")
-            self.downloadZipFileFile(from: downloadURL,to:documentsURL) { result in
-                switch result {
-                case .success(let savedURL):
-                    self.unzipFile(at: savedURL, to: documentsURL)
-                    self.downloadFailed = false
-                    
-                    NSLog("Zip file saving completed: \(savedURL)")
-                case .failure(let error):
-                    self.downloadFailed = true
-                    NSLog("Failed to save zip file: \(error)")
+        NSLog("Start obtaining Resouce. \(modelData.getCurrentAddress())")
+        if let resouceFileURL = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/app-resource.zip"){
+            
+            let configuration = URLSessionConfiguration.default
+            configuration.timeoutIntervalForRequest = timeout
+            let session = URLSession(configuration: configuration)
+            
+            let task = session.dataTask(with: resouceFileURL) { (data, response, error) in
+                if let error = error {
+                    if retries > 0 {
+                        NSLog("Download failed. Attempt to retry. Remaining number of retries: \(retries)")
+                        self.downloadResouceFile(retries: retries - 1, timeout: timeout, modelData: modelData, completion: completion)
+                    } else {
+                        completion(.failure(error))
+                    }
+                    return
                 }
-            }
-        }else{
-            self.downloadFailed = true
-        }
-    }
-    
-    
-    
-    
-    func downloadZipFileFile(from url: URL, to destinationFolderURL: URL,retries:Int = 3, completion: @escaping (Result<URL, Error>) -> Void) {
-        let task = URLSession.shared.downloadTask(with: url) { (localURL, response, error) in
-            guard let localURL = localURL else {
-                let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "File URL is nil"])
-                completion(.failure(error))
-                return
+                
+                guard let data = data else {
+                    let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
+                    completion(.failure(error))
+                    return
+                }
+                
+                // Save the downloaded data to a file in Documents directory
+                let documentsURL = getDocumentsDirectory()
+                
+                
+                let fileURL = documentsURL.appendingPathComponent("app-resource.zip")
+                
+                // Delete existing file if present
+                do {
+                    if FileManager.default.fileExists(atPath: fileURL.path) {
+                        try FileManager.default.removeItem(at: fileURL)
+                        NSLog("Deleted existing file at \(fileURL)")
+                    }
+                } catch {
+                    NSLog("Failed to delete existing file: \(error.localizedDescription)")
+                    completion(.failure(error))
+                    return
+                }
+                // Save new file
+                do {
+                    try data.write(to: fileURL)
+                    NSLog("File saved successfully at \(fileURL)")
+                    self.unzipFile(at: fileURL,to: documentsURL,modelData: modelData)
+                } catch {
+                    NSLog("Failed to save file: \(error.localizedDescription)")
+                    completion(.failure(error))
+                    return
+                }
+                
+                completion(.success(data))
             }
             
-            do {
-                let destinationURL = destinationFolderURL.appendingPathComponent(url.lastPathComponent)
-                
-                //Delete if file already exists
-                if FileManager.default.fileExists(atPath: destinationURL.path) {
-                    try FileManager.default.removeItem(at: destinationURL)
-                }
-                
-                // Move the downloaded file to the specified folder
-                try FileManager.default.moveItem(at: localURL, to: destinationURL)
-                completion(.success(destinationURL))
-            } catch {
-                completion(.failure(error))
-            }
+            task.resume()
         }
-        task.resume()
     }
     
     
     //Process of unzipping a ZIP resource file
-    func unzipFile(at sourceURL:URL,to destinaltionURL:URL)
-    {
+    func unzipFile(at sourceURL:URL,to destinaltionURL:URL,modelData: CaBotAppModel){
         let fileManager = FileManager()
         let unzipFileName = "app-resource"//resource file name
         let unzipedFilePath = destinaltionURL.appendingPathComponent(unzipFileName)//Unzipped resource file URL
@@ -327,82 +353,87 @@ final class ResourceDownload :NSObject, ObservableObject{
                 NSLog("ZIP file deleted after unzipping")
             }
             
+            DispatchQueue.main.async{
+                modelData.resourceManager.updateResources()
+                if(modelData.resourceManager.resources.count>0){
+                    modelData.resource = modelData.resourceManager.resources[0]
+                }
+            }
         }catch{
             NSLog("An error occurred while unzipping！")
         }
     }
-    //Retry after Get Resource
-    public func getAllResources() -> [Resource] {
-        var list: [Resource] = []
-        
-        let resourceRoot = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        
-        let fm = FileManager.default
-        let enumerator: FileManager.DirectoryEnumerator? = fm.enumerator(at: resourceRoot, includingPropertiesForKeys: [.isDirectoryKey], options: [], errorHandler: nil)
-        
-        while let dir = enumerator?.nextObject() as? URL {
-            if fm.fileExists(atPath: dir.appendingPathComponent(Resource.METADATA_FILE_NAME).path) {
-                do {
-                    let model = try Resource(at: dir)
-                    NSLog("Unzipping completed！\(model.name)")
-                    list.append(model)
-                } catch (let error) {
-                    NSLog(error.localizedDescription)
-                }
+    
+    func SpeechErrorMessage(modelData: CaBotAppModel)
+    {
+        DispatchQueue.main.async {
+            let _ = modelData.resourceDownload.speakCount += 1
+            //Read-aloud is only once
+            if modelData.resourceDownload.speakCount == 1
+            {
+                NSLog("Error message read out loud")
+                let message = CustomLocalizedString("Retry Alert", lang: modelData.resourceLang)
+                modelData.speak(message) {}
+                
             }
         }
+    }
+    
+    //Delete hash files on retry
+    func deleteHashFile(){
+        let hashFileName = "hashFile.txt"//Hash file name saved within the app
+        let hashFileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
+        //Delete if file already exists
+        if FileManager.default.fileExists(atPath: hashFileURL.path) {
+            do{
+                NSLog("Hash file deletion completed:\(hashFileURL.path)")
+                try FileManager.default.removeItem(at: hashFileURL)
+            }catch{
+                NSLog("Hash file deletion failed:\(error.localizedDescription)")
+            }
+            
+        }
+        let resourceFileName = "app-resource"//Resource file name saved within the app
+        let resourceFileURL = getDocumentsDirectory().appendingPathComponent(resourceFileName)
         
-        return list
+        if FileManager.default.fileExists(atPath: resourceFileURL.path) {
+            do{
+                NSLog("Resource file deletion completed:\(resourceFileURL.path)")
+                try FileManager.default.removeItem(at: resourceFileURL)
+            }catch{
+                NSLog("Resource file deletion failed:\(error.localizedDescription)")
+            }
+            
+        }
     }
     
 }//Class Resource End
 
 
-
 //Display error message and retry button when resource download fails
 struct ResourceDownloadRetryUIView :View {
     @EnvironmentObject var modelData: CaBotAppModel
-    @StateObject var resourceDownload = ResourceDownload()
-    @State var _resources: [Resource] = []
     var body: some View {
-        if modelData.resource == nil{
-            if(resourceDownload.getAllResources().count>0){
-                let _ =  modelData.resource = resourceDownload.getAllResources()[0]
-            }
+        
+        if modelData.suitcaseConnected{
+            let _ =   modelData.resourceDownload.startDownloadResourceOnSuitcaseConnected(modelData: modelData)
+        }else{
+            let _ =   modelData.resourceDownload.startDownloadResourceOnSuitcaseUnconnected(modelData: modelData)
         }
+        
         //If ownload fails, an error message and retry will be displayed
-        if resourceDownload.downloadFailed
+        if modelData.resource == nil
         {
-            let _ = resourceDownload.speakCount += 1
-            //Read-aloud is only once
-            if resourceDownload.speakCount == 1
-            {
-                let _ =  NSLog("Error message read out loud")
-                let message = CustomLocalizedString("RetryAlert", lang: modelData.resourceLang)
-                let _ = modelData.speak(message) {}
-            }
-            
-            Section(header:  Text(CustomLocalizedString("ResourceDownload", lang: modelData.resourceLang))){
+            Section(header:  Text(CustomLocalizedString("Resource Download", lang: modelData.resourceLang))){
                 
-                Text(CustomLocalizedString("RetryAlert", lang: modelData.resourceLang)).font(.body).foregroundColor(.red).lineLimit(1)
+                Text(CustomLocalizedString("Retry Alert", lang: modelData.resourceLang)).font(.body).foregroundColor(.red).lineLimit(1)
                 
                 Button(action: {
-                    let _: () = resourceDownload.startFileDownload()
+                    let _: () = modelData.resourceDownload.startFileDownload(modelData: modelData)
                 },label: {
                     Text(CustomLocalizedString("Retry", lang: modelData.resourceLang)).foregroundColor(.blue)
                 })
             }
-        }else{
-            let _ = resourceDownload.speakCount = 0
-            //First time Donwload. Run only once
-            if !resourceDownload.isTryFirstDownloaded{
-                
-                let _: () = resourceDownload.startFileDownload()
-                
-            }
-            
-            
         }
-        
     }
 }

--- a/CaBot/ResourceDownload.swift
+++ b/CaBot/ResourceDownload.swift
@@ -26,412 +26,234 @@ import CommonCrypto
 import ZIPFoundation
 import SwiftUI
 
-//Get document directory
-func getDocumentsDirectory() -> URL{
+// Get document directory
+func getDocumentsDirectory() -> URL {
     guard let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
         fatalError("Could not find the document directory.")
     }
     return path
 }
 
-//Since there is no Hash file in the app, save it for the first time
-func saveHashTextFile(fileName:String,content:String){
-    let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
-    
-    //Check file existence
-    if FileManager.default.fileExists(atPath: fileURL.path){
-        //do nothing
-    }else{//If the file does not exist, create a new one
-        do{
-            try content.write(to:fileURL, atomically: true, encoding: .utf8)
-            NSLog("Saving of Hash file is completed:\(fileURL.path)")
-        }catch{
-            NSLog("Saving Hash file failed:\(error.localizedDescription)")
-        }
-    }
-}
-
-
-//Overwrite the existing Hash text file in the app
-func overwriteHashTextFile(fileName:String,content:String){
-    let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
-    
-    //Check file existence
-    if FileManager.default.fileExists(atPath: fileURL.path){
-        do{
-            try content.write(to:fileURL, atomically: true, encoding: .utf8)
-            NSLog("Hash file overwriting completed:\(fileURL.path)")
-        }catch{
-            NSLog("Hash file overwriting failed:\(error.localizedDescription)")
-        }
-        
-    }
-}
-//Check Server
-func checkServerStatus(url: URL, completion: @escaping (Bool) -> Void) {
-    let task = URLSession.shared.dataTask(with: url) { data, response, error in
-        if let error = error {
-            NSLog("Error: \(error)")
-            completion(false)
-            return
-        }
-        
-        if let httpResponse = response as? HTTPURLResponse {
-            if httpResponse.statusCode == 200 {
-                completion(true)
-            } else {
-                NSLog("ServerError: \(httpResponse.statusCode)")
-                completion(false)
-            }
-        } else {
-            NSLog("invalid response")
-            completion(false)
-        }
-    }
-    task.resume()
-}
-
-
-//resource download
+// Resource download
 class ResourceDownload {
-    var isStartDownloadedOnSuitcaseConnected:Bool = true//First download When Suitcase is Connected
-    var isStartDownloadedOnSuitcaseUnconnected:Bool = true//First download When Suitcase is not Connected
-    var speakCount : Int = 0
-    var m5HashValue:String = ""//hash Value
-    //Download Resources When Suitcase is Connected. call only once when app start.
-    func startDownloadResourceOnSuitcaseConnected(modelData: CaBotAppModel){
-        if isStartDownloadedOnSuitcaseConnected{
+    var isStartDownloadedOnSuitcaseConnected: Bool = true // First download When Suitcase is Connected
+    var isStartDownloadedOnSuitcaseUnconnected: Bool = true // First download When Suitcase is not Connected
+    var m5HashValue: String = "" // hash Value
+    private let md5HashKey = "Md5HashKey"
+    
+    // Download Resources When Suitcase is Connected. Call only once when app start.
+    func startDownloadResourceOnSuitcaseConnected(modelData: CaBotAppModel) {
+        if isStartDownloadedOnSuitcaseConnected {
             isStartDownloadedOnSuitcaseConnected = false
             self.startFileDownload(modelData: modelData)
         }
     }
-    //Download Resources When Suitcase is not Connected. call only once when app start.
-    func startDownloadResourceOnSuitcaseUnconnected(modelData: CaBotAppModel){
-        if isStartDownloadedOnSuitcaseUnconnected{
+    
+    // Download Resources When Suitcase is not Connected. Call only once when app start.
+    func startDownloadResourceOnSuitcaseUnconnected(modelData: CaBotAppModel) {
+        if isStartDownloadedOnSuitcaseUnconnected {
             isStartDownloadedOnSuitcaseUnconnected = false
             self.startFileDownload(modelData: modelData)
         }
     }
+    
     // Call the file download method when the app starts
-    public func startFileDownload(modelData: CaBotAppModel) {
-        let hashFileName = "hashFile.txt"
-        self.downloadHashFile(modelData: modelData) { result in
+    func startFileDownload(modelData: CaBotAppModel) {
+        let hashFileName = "app-resource-md5"
+        let resourceFileName = "app-resource.zip"
+        
+        self.downloadFile(fileType: "HashFile", fileNmae: hashFileName, modelData: modelData) {result in
             switch result {
             case .success(let data):
-                guard let content = String(data: data, encoding: .utf8) else {
-                    return
-                }
-                let lines = content.split(separator: "\n")
-                for line in lines {
-                    let components = line.split(separator: " ")
-                    guard components.count == 1 else {
-                        NSLog("Component count is not 1")
-                        return
-                    }
-                    self.m5HashValue = String(components[0])
-                    let fileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
-                    if FileManager.default.fileExists(atPath: fileURL.path) {
-                        if let hashFileContent = self.readHashTextFile(fileName: hashFileName) {
-                            NSLog("File content:\(hashFileContent)")
-                            //Hash value is the same
-                            if hashFileContent == self.m5HashValue {
-                                //Determine whether the server can be accessed
-                                if let url = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/app-resource.zip") {
-                                    checkServerStatus(url: url) { isOnline in
-                                        if isOnline {
-                                            DispatchQueue.main.async{
-                                                modelData.resourceManager.updateResources()
-                                                if(modelData.resourceManager.resources.count>0){
-                                                    modelData.resource = modelData.resourceManager.resources[0]
-                                                }
-                                            }
-                                        } else {
-                                            NSLog("The server is down")
-                                        }
-                                    }
-                                }
-                                
-                                NSLog("MD5 hash matched: \(self.m5HashValue)")
-                            } else {
-                                NSLog("MD5 hashes don't match: \(self.m5HashValue)")
-                                overwriteHashTextFile(fileName: hashFileName, content: self.m5HashValue)
-                                self.downloadResouceFile(modelData: modelData){ result in
-                                    switch result {
-                                    case .success(let data):
-                                        NSLog("Download succeeded. Data received: \(data)")
-                                    case .failure(let error):
-                                        DispatchQueue.main.async{
-                                            self.speakCount = 0
-                                            self.SpeechErrorMessage(modelData: modelData)
-                                            self.deleteHashFile()
-                                        }
-                                        NSLog("Download failed with error: \(error.localizedDescription)")
-                                    }
-                                }
-                            }
-                        } else {
-                            NSLog("Failed to get Hash value")
-                        }
-                    } else {
-                        saveHashTextFile(fileName: hashFileName, content: self.m5HashValue)
-                        self.downloadResouceFile(modelData: modelData){ result in
-                            switch result {
-                            case .success(let data):
-                                NSLog("Download succeeded. Data received: \(data)")
-                            case .failure(let error):
-                                DispatchQueue.main.async{
-                                    self.speakCount = 0
-                                    self.SpeechErrorMessage(modelData: modelData)
-                                    self.deleteHashFile()
-                                }
-                                NSLog("Download failed with error: \(error.localizedDescription)")
-                            }
-                        }
-                    }
-                }
+                self.processHashFile(data, modelData: modelData, resourceFileName: resourceFileName)
             case .failure(let error):
-                DispatchQueue.main.async{
-                    self.speakCount = 0
+                DispatchQueue.main.async {
                     self.SpeechErrorMessage(modelData: modelData)
-                    self.deleteHashFile()
                 }
-                NSLog("Failed to download hash file：\(error)")
+                NSLog("Failed to download hash file: \(error.localizedDescription)")
             }
         }
-    }//startFileDownload end
+    }
     
-    //Get hash value
-    func downloadHashFile(retries: Int = 3,timeout: TimeInterval = 2,modelData: CaBotAppModel, completion: @escaping (Result<Data, Error>) -> Void) {
-        
-        NSLog("Start obtaining hash value. \(modelData.getCurrentAddress())")
-        if let md5FileURL = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/app-resource-md5"){
+    func processHashFile(_ data: Data, modelData: CaBotAppModel, resourceFileName: String) {
+        guard let content = String(data: data, encoding: .utf8) else {
+            return
+        }
+        let lines = content.split(separator: "\n")
+        for line in lines {
+            let components = line.split(separator: " ")
+            guard components.count == 1 else {
+                NSLog("Component count is not 1")
+                return
+            }
+            let newHashValue = String(components[0])
+            let storedHashValue = UserDefaults.standard.string(forKey: md5HashKey)
             
+            if newHashValue == storedHashValue {
+                DispatchQueue.main.async {
+                    modelData.resourceManager.updateResources()
+                    if modelData.resourceManager.resources.count > 0 {
+                        modelData.resource = modelData.resourceManager.resources[0]
+                    }
+                }
+                NSLog("MD5 hash matched: \(newHashValue) === \(String(describing: storedHashValue))")
+            } else {
+                handleHashMismatch(newHashValue: newHashValue, resourceFileName: resourceFileName, modelData: modelData)
+            }
+        }
+    }
+    
+    func handleHashMismatch(newHashValue: String, resourceFileName: String, modelData: CaBotAppModel) {
+        NSLog("MD5 hashes don't match: \(newHashValue)")
+        deleteResourceFile()
+        UserDefaults.standard.setValue(newHashValue, forKey: md5HashKey)
+        downloadFile(fileType: "ResourceFile", fileNmae: resourceFileName, modelData: modelData) { result in
+            switch result {
+            case .success(let data):
+                NSLog("Download succeeded. Data received: \(data)")
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    self.SpeechErrorMessage(modelData: modelData)
+                }
+                NSLog("Download failed with error: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func downloadFile(fileType: String, fileNmae: String, retries: Int = 3, timeout: TimeInterval = 2, modelData: CaBotAppModel, completion: @escaping (Result<Data, Error>) -> Void) {
+        NSLog("Start obtaining hash value. \(modelData.getCurrentAddress())")
+        if let filePath = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/\(fileNmae)") {
             // Configure the URLSession with timeout
             let configuration = URLSessionConfiguration.default
+            configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
             configuration.timeoutIntervalForRequest = timeout
             let session = URLSession(configuration: configuration)
-            
-            let task = session.dataTask(with: md5FileURL) { (data, response, error) in
-                
-                if let error = error  {
-                    if (error as NSError).code == NSURLErrorCannotConnectToHost {
-                        NSLog("Failed to connect to host: \(md5FileURL). The server might not be running.")
-                        let connectionError = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to connect to host: \(md5FileURL). The server might not be running."])
-                        completion(.failure(connectionError))
-                    }else{
-                        if retries > 0{
-                            NSLog("Download failed. Attempt to retry. Remaining number of retries: \(retries)")
-                            self.downloadHashFile( retries: retries - 1,timeout: timeout,modelData: modelData, completion: completion)
-                        }else{
-                            completion(.failure(error))
-                        }
-                    }
-                    
-                    return
-                }
-                
-                guard let data = data else {
-                    let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
-                    if retries > 0 {
-                        NSLog("No data received. Attempt to retry. Remaining number of retries: \(retries - 1)")
-                        DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                            self.downloadHashFile(retries: retries - 1, timeout: timeout, modelData: modelData, completion: completion)
-                        }
-                    } else {
-                        completion(.failure(error))
-                    }
-                    return
-                }
-                completion(.success(data))
-            }
-            task.resume()
-        }
-        
-    }
-    
-    //Read Hash text file in app
-    func readHashTextFile(fileName:String) -> String?{
-        
-        let fileURL=getDocumentsDirectory().appendingPathComponent(fileName)
-        do{
-            let content = try String(contentsOf:fileURL,encoding: .utf8)
-            NSLog("Read Hash file")
-            
-            //self.downloadFailed = false
-            return content
-            
-        }catch{
-            NSLog("Reading Hash file failed:\(error.localizedDescription)")
-            return nil
-        }
-    }
-    
-    
-    func downloadResouceFile(retries: Int = 3,timeout: TimeInterval = 2,modelData: CaBotAppModel, completion: @escaping (Result<Data, Error>) -> Void) {
-        
-        NSLog("Start obtaining Resouce. \(modelData.getCurrentAddress())")
-        if let resouceFileURL = URL(string: "http://\(modelData.getCurrentAddress()):9090/map/app-resource.zip"){
-            
-            let configuration = URLSessionConfiguration.default
-            configuration.timeoutIntervalForRequest = timeout
-            let session = URLSession(configuration: configuration)
-            
-            let task = session.dataTask(with: resouceFileURL) { (data, response, error) in
+            let task = session.dataTask(with: filePath) { (data, response, error) in
                 if let error = error {
                     if retries > 0 {
                         NSLog("Download failed. Attempt to retry. Remaining number of retries: \(retries)")
-                        self.downloadResouceFile(retries: retries - 1, timeout: timeout, modelData: modelData, completion: completion)
+                        self.downloadFile(fileType: fileType, fileNmae: fileNmae, retries: retries - 1, timeout: timeout, modelData: modelData, completion: completion)
                     } else {
                         completion(.failure(error))
                     }
                     return
                 }
-                
                 guard let data = data else {
-                    let error = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
-                    completion(.failure(error))
+                    _ = NSError(domain: "FileDownloader", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])
                     return
                 }
-                
-                // Save the downloaded data to a file in Documents directory
-                let documentsURL = getDocumentsDirectory()
-                
-                
-                let fileURL = documentsURL.appendingPathComponent("app-resource.zip")
-                
-                // Delete existing file if present
-                do {
-                    if FileManager.default.fileExists(atPath: fileURL.path) {
-                        try FileManager.default.removeItem(at: fileURL)
-                        NSLog("Deleted existing file at \(fileURL)")
-                    }
-                } catch {
-                    NSLog("Failed to delete existing file: \(error.localizedDescription)")
-                    completion(.failure(error))
-                    return
+                if fileType == "ResourceFile" {
+                    // Save the downloaded data to a file in Documents directory
+                    self.saveResourceFile(data: data, modelData: modelData, completion: completion)
                 }
-                // Save new file
-                do {
-                    try data.write(to: fileURL)
-                    NSLog("File saved successfully at \(fileURL)")
-                    self.unzipFile(at: fileURL,to: documentsURL,modelData: modelData)
-                } catch {
-                    NSLog("Failed to save file: \(error.localizedDescription)")
-                    completion(.failure(error))
-                    return
-                }
-                
                 completion(.success(data))
             }
-            
             task.resume()
         }
     }
     
+    private func saveResourceFile(data: Data, modelData: CaBotAppModel, completion: @escaping (Result<Data, Error>) -> Void) {
+        let documentsURL = getDocumentsDirectory()
+        let fileURL = documentsURL.appendingPathComponent("app-resource.zip")
+        
+        do {
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                try FileManager.default.removeItem(at: fileURL)
+                NSLog("Deleted existing file at \(fileURL)")
+            }
+            try data.write(to: fileURL)
+            NSLog("File saved successfully at \(fileURL)")
+            self.unzipFile(at: fileURL, to: documentsURL, modelData: modelData)
+        } catch {
+            NSLog("Failed to save file: \(error.localizedDescription)")
+            completion(.failure(error))
+            return
+        }
+        
+        completion(.success(data))
+    }
     
-    //Process of unzipping a ZIP resource file
-    func unzipFile(at sourceURL:URL,to destinaltionURL:URL,modelData: CaBotAppModel){
+    // Process of unzipping a ZIP resource file
+    func unzipFile(at sourceURL: URL, to destinaltionURL: URL, modelData: CaBotAppModel) {
         let fileManager = FileManager()
-        let unzipFileName = "app-resource"//resource file name
-        let unzipedFilePath = destinaltionURL.appendingPathComponent(unzipFileName)//Unzipped resource file URL
-        do{
-            //Delete previously unzipped files if they exist
+        let unzipFileName = "app-resource" // Resource file name
+        let unzipedFilePath = destinaltionURL.appendingPathComponent(unzipFileName) // Unzipped resource file URL
+        do {
+            // Delete previously unzipped files if they exist
             if FileManager.default.fileExists(atPath: unzipedFilePath.path) {
                 try FileManager.default.removeItem(at: unzipedFilePath)
-                NSLog("Existing unzipped files deleted\(unzipedFilePath)")
-                
+                NSLog("Existing unzipped files deleted \(unzipedFilePath)")
             }
-            
-            //Thawing process
-            try fileManager.createDirectory(at: destinaltionURL, withIntermediateDirectories: true,attributes:nil)
+            // Thawing process
+            try fileManager.createDirectory(at: destinaltionURL, withIntermediateDirectories: true, attributes: nil)
             try fileManager.unzipItem(at: sourceURL, to: destinaltionURL)
-            
             NSLog("Unzipping completed！\(destinaltionURL)")
-            //Delete the ZIP file if it exists after unzipping it
+            // Delete the ZIP file if it exists after unzipping it
             if FileManager.default.fileExists(atPath: sourceURL.path) {
                 try FileManager.default.removeItem(at: sourceURL)
                 NSLog("ZIP file deleted after unzipping")
             }
-            
-            DispatchQueue.main.async{
+            DispatchQueue.main.async {
                 modelData.resourceManager.updateResources()
-                if(modelData.resourceManager.resources.count>0){
+                if modelData.resourceManager.resources.count > 0 {
                     modelData.resource = modelData.resourceManager.resources[0]
                 }
             }
-        }catch{
+        } catch {
             NSLog("An error occurred while unzipping！")
         }
     }
     
-    func SpeechErrorMessage(modelData: CaBotAppModel)
-    {
+    func SpeechErrorMessage(modelData: CaBotAppModel) {
         DispatchQueue.main.async {
-            let _ = modelData.resourceDownload.speakCount += 1
-            //Read-aloud is only once
-            if modelData.resourceDownload.speakCount == 1
-            {
-                NSLog("Error message read out loud")
-                let message = CustomLocalizedString("Retry Alert", lang: modelData.resourceLang)
-                modelData.speak(message) {}
-                
-            }
+            NSLog("Error message read out loud")
+            let message = CustomLocalizedString("Retry Alert", lang: modelData.resourceLang)
+            modelData.speak(message) {}
         }
     }
     
-    //Delete hash files on retry
-    func deleteHashFile(){
-        let hashFileName = "hashFile.txt"//Hash file name saved within the app
-        let hashFileURL = getDocumentsDirectory().appendingPathComponent(hashFileName)
-        //Delete if file already exists
-        if FileManager.default.fileExists(atPath: hashFileURL.path) {
-            do{
-                NSLog("Hash file deletion completed:\(hashFileURL.path)")
-                try FileManager.default.removeItem(at: hashFileURL)
-            }catch{
-                NSLog("Hash file deletion failed:\(error.localizedDescription)")
-            }
-            
-        }
-        let resourceFileName = "app-resource"//Resource file name saved within the app
+    // Delete hash files on retry
+    func deleteHashKey() {
+        UserDefaults.standard.removeObject(forKey: self.md5HashKey)
+    }
+    // Delete Resource files
+    func deleteResourceFile() {
+        let resourceFileName = "app-resource" // Resource file name saved within the app
         let resourceFileURL = getDocumentsDirectory().appendingPathComponent(resourceFileName)
-        
         if FileManager.default.fileExists(atPath: resourceFileURL.path) {
-            do{
-                NSLog("Resource file deletion completed:\(resourceFileURL.path)")
+            do {
+                NSLog("Resource file deletion completed: \(resourceFileURL.path)")
                 try FileManager.default.removeItem(at: resourceFileURL)
-            }catch{
-                NSLog("Resource file deletion failed:\(error.localizedDescription)")
+            } catch {
+                NSLog("Resource file deletion failed: \(error.localizedDescription)")
             }
-            
         }
     }
-    
-}//Class Resource End
+}
 
-
-//Display error message and retry button when resource download fails
-struct ResourceDownloadRetryUIView :View {
+// Display error message and retry button when resource download fails
+struct ResourceDownloadRetryUIView: View {
     @EnvironmentObject var modelData: CaBotAppModel
     var body: some View {
-        
-        if modelData.suitcaseConnected{
-            let _ =   modelData.resourceDownload.startDownloadResourceOnSuitcaseConnected(modelData: modelData)
-        }else{
-            let _ =   modelData.resourceDownload.startDownloadResourceOnSuitcaseUnconnected(modelData: modelData)
+        if modelData.suitcaseConnected {
+            let _ = modelData.resourceDownload.startDownloadResourceOnSuitcaseConnected(modelData: modelData)
+        } else {
+            let _ = modelData.resourceDownload.startDownloadResourceOnSuitcaseUnconnected(modelData: modelData)
         }
-        
-        //If ownload fails, an error message and retry will be displayed
-        if modelData.resource == nil
-        {
-            Section(header:  Text(CustomLocalizedString("Resource Download", lang: modelData.resourceLang))){
-                
-                Text(CustomLocalizedString("Retry Alert", lang: modelData.resourceLang)).font(.body).foregroundColor(.red).lineLimit(1)
-                
+        // If download fails, an error message and retry will be displayed
+        if modelData.resource == nil {
+            Section(header: Text(CustomLocalizedString("Resource Download", lang: modelData.resourceLang))) {
+                Text(CustomLocalizedString("Retry Alert", lang: modelData.resourceLang))
+                    .font(.body)
+                    .foregroundColor(.red)
+                    .lineLimit(1)
                 Button(action: {
+                    let _: () = modelData.resourceDownload.deleteHashKey()
+                    let _: () = modelData.resourceDownload.deleteResourceFile()
                     let _: () = modelData.resourceDownload.startFileDownload(modelData: modelData)
-                },label: {
-                    Text(CustomLocalizedString("Retry", lang: modelData.resourceLang)).foregroundColor(.blue)
+                }, label: {
+                    Text(CustomLocalizedString("Retry", lang: modelData.resourceLang))
+                        .foregroundColor(.blue)
                 })
             }
         }

--- a/CaBot/ResourceManager.swift
+++ b/CaBot/ResourceManager.swift
@@ -1010,12 +1010,12 @@ class ResourceManager {
 
     func getResourceRoot() -> URL {
         if preview {
-            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!//Bundle.main.resourceURL
-            return path//!.appendingPathComponent("PreviewResource")
+            let path = Bundle.main.resourceURL
+            return path!.appendingPathComponent("PreviewResource")
 
         } else {
-            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!//Bundle.main.resourceURL
-            return path//!.appendingPathComponent("Resource")
+            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            return path
         }
     }
 

--- a/CaBot/ResourceManager.swift
+++ b/CaBot/ResourceManager.swift
@@ -1010,12 +1010,12 @@ class ResourceManager {
 
     func getResourceRoot() -> URL {
         if preview {
-            let path = Bundle.main.resourceURL
-            return path!.appendingPathComponent("PreviewResource")
+            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!//Bundle.main.resourceURL
+            return path//!.appendingPathComponent("PreviewResource")
 
         } else {
-            let path = Bundle.main.resourceURL
-            return path!.appendingPathComponent("Resource")
+            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!//Bundle.main.resourceURL
+            return path//!.appendingPathComponent("Resource")
         }
     }
 

--- a/CaBot/ResourceManager.swift
+++ b/CaBot/ResourceManager.swift
@@ -1014,7 +1014,9 @@ class ResourceManager {
             return path!.appendingPathComponent("PreviewResource")
 
         } else {
-            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            guard let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                fatalError("Could not find the document directory.")
+            }
             return path
         }
     }

--- a/CaBot/Views/Attend/MainMenuView.swift
+++ b/CaBot/Views/Attend/MainMenuView.swift
@@ -28,6 +28,8 @@ struct MainMenuView: View {
 
     var body: some View {
         Form {
+            ResourceDownloadRetryUIView()
+                .environmentObject(modelData)
             UserInfoView()
                 .environmentObject(modelData)
             if modelData.noSuitcaseDebug {

--- a/CaBot/Views/ResourceSelectView.swift
+++ b/CaBot/Views/ResourceSelectView.swift
@@ -30,18 +30,27 @@ struct ResourceSelectView: View {
     var body: some View {
         Form {
             Section() {
-                ForEach (model.resourceManager.resources, id: \.self) { resource in
+                if model.resourceManager.resources.count == 0
+                {
                     Button(action: {
-                        UserDefaults.standard.setValue(true, forKey: ResourceSelectView.resourceSelectedKey)
-                        UserDefaults.standard.synchronize()
-                        model.resource = resource
-                        withAnimation() {
-                            model.displayedScene = .App
-                        }
+                        model.displayedScene = .App
                     }) {
-                        HStack {
-                            Image(systemName: "folder")
-                            Text("\(resource.name)")
+                        Text(CustomLocalizedString("ReturnMainmenu", lang: model.resourceLang))
+                    }
+                }else{
+                    ForEach (model.resourceManager.resources, id: \.self) { resource in
+                        Button(action: {
+                            UserDefaults.standard.setValue(true, forKey: ResourceSelectView.resourceSelectedKey)
+                            UserDefaults.standard.synchronize()
+                            model.resource = resource
+                            withAnimation() {
+                                model.displayedScene = .App
+                            }
+                        }) {
+                            HStack {
+                                Image(systemName: "folder")
+                                Text("\(resource.name)")
+                            }
                         }
                     }
                 }

--- a/CaBot/Views/ResourceSelectView.swift
+++ b/CaBot/Views/ResourceSelectView.swift
@@ -30,27 +30,18 @@ struct ResourceSelectView: View {
     var body: some View {
         Form {
             Section() {
-                if model.resourceManager.resources.count == 0
-                {
+                ForEach (model.resourceManager.resources, id: \.self) { resource in
                     Button(action: {
-                        model.displayedScene = .App
+                        UserDefaults.standard.setValue(true, forKey: ResourceSelectView.resourceSelectedKey)
+                        UserDefaults.standard.synchronize()
+                        model.resource = resource
+                        withAnimation() {
+                            model.displayedScene = .App
+                        }
                     }) {
-                        Text(CustomLocalizedString("ReturnMainmenu", lang: model.resourceLang))
-                    }
-                }else{
-                    ForEach (model.resourceManager.resources, id: \.self) { resource in
-                        Button(action: {
-                            UserDefaults.standard.setValue(true, forKey: ResourceSelectView.resourceSelectedKey)
-                            UserDefaults.standard.synchronize()
-                            model.resource = resource
-                            withAnimation() {
-                                model.displayedScene = .App
-                            }
-                        }) {
-                            HStack {
-                                Image(systemName: "folder")
-                                Text("\(resource.name)")
-                            }
+                        HStack {
+                            Image(systemName: "folder")
+                            Text("\(resource.name)")
                         }
                     }
                 }

--- a/CaBot/Views/RootView.swift
+++ b/CaBot/Views/RootView.swift
@@ -89,7 +89,6 @@ struct RootView: View {
                              })
             }
         }
-        .environment(\.locale, modelData.resource?.locale ?? .init(identifier: "base"))
     }
 }
 

--- a/CaBot/Views/SettingView.swift
+++ b/CaBot/Views/SettingView.swift
@@ -38,6 +38,7 @@ struct SettingView: View {
                     UserDefaults.standard.setValue(false, forKey: ResourceSelectView.resourceSelectedKey)
                     UserDefaults.standard.synchronize()
                     modelData.displayedScene = .ResourceSelect
+                    modelData.resourceManager.updateResources()
                     presentationMode.wrappedValue.dismiss()
                 }) {
                     Text("SELECT_RESOURCE")

--- a/CaBot/Views/SettingView.swift
+++ b/CaBot/Views/SettingView.swift
@@ -34,7 +34,7 @@ struct SettingView: View {
     var body: some View {
         return Form {
             Section(header: Text("Settings")){
-                Button(action: {
+               /* Button(action: {
                     UserDefaults.standard.setValue(false, forKey: ResourceSelectView.resourceSelectedKey)
                     UserDefaults.standard.synchronize()
                     modelData.displayedScene = .ResourceSelect
@@ -42,7 +42,7 @@ struct SettingView: View {
                     presentationMode.wrappedValue.dismiss()
                 }) {
                     Text("SELECT_RESOURCE")
-                }
+                }*/
 
                 if let resource = modelData.resource {
                     Picker("LANGUAGE", selection: $langOverride) {

--- a/CaBot/Views/SettingView.swift
+++ b/CaBot/Views/SettingView.swift
@@ -34,16 +34,6 @@ struct SettingView: View {
     var body: some View {
         return Form {
             Section(header: Text("Settings")){
-               /* Button(action: {
-                    UserDefaults.standard.setValue(false, forKey: ResourceSelectView.resourceSelectedKey)
-                    UserDefaults.standard.synchronize()
-                    modelData.displayedScene = .ResourceSelect
-                    modelData.resourceManager.updateResources()
-                    presentationMode.wrappedValue.dismiss()
-                }) {
-                    Text("SELECT_RESOURCE")
-                }*/
-
                 if let resource = modelData.resource {
                     Picker("LANGUAGE", selection: $langOverride) {
                         ForEach(resource.languages, id: \.self) { language in

--- a/CaBot/Views/User/MainMenuView.swift
+++ b/CaBot/Views/User/MainMenuView.swift
@@ -38,6 +38,8 @@ struct MainMenuView: View {
             }
             DestinationMenus()
                 .environmentObject(modelData)
+            ResourceDownloadRetryUIView()
+                .environmentObject(modelData)
             MainMenus()
                 .environmentObject(modelData)
                 .disabled(!modelData.suitcaseConnected && !modelData.menuDebug)

--- a/CaBot/en.lproj/Localizable.strings
+++ b/CaBot/en.lproj/Localizable.strings
@@ -291,3 +291,7 @@
 "Restart Localization"="Restart Localization";
 "Restarting Localization"="Restarting Localization";
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
+
+//Resource Download Alert View
+"RetryAlert" = "Check the connection with the server,Please！";
+"Retry" = "Retry";

--- a/CaBot/en.lproj/Localizable.strings
+++ b/CaBot/en.lproj/Localizable.strings
@@ -293,7 +293,7 @@
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
 
 //Resource Download Alert View
-"RetryAlert" = "Check the connection with the server！";
+"RetryAlert" = "Check the connection with the server!";
 "Retry" = "Retry";
 "ReturnMainmenu" = "ReturnMainMenu";
 "ResourceDownload" = "Resource Download";

--- a/CaBot/en.lproj/Localizable.strings
+++ b/CaBot/en.lproj/Localizable.strings
@@ -295,3 +295,4 @@
 //Resource Download Alert View
 "RetryAlert" = "Check the connection with the server,Please！";
 "Retry" = "Retry";
+"ReturnMainmenu" = "ReturnMainMenu";

--- a/CaBot/en.lproj/Localizable.strings
+++ b/CaBot/en.lproj/Localizable.strings
@@ -293,6 +293,7 @@
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
 
 //Resource Download Alert View
-"RetryAlert" = "Check the connection with the server,Please！";
+"RetryAlert" = "Check the connection with the server！";
 "Retry" = "Retry";
 "ReturnMainmenu" = "ReturnMainMenu";
+"ResourceDownload" = "Resource Download";

--- a/CaBot/en.lproj/Localizable.strings
+++ b/CaBot/en.lproj/Localizable.strings
@@ -293,7 +293,7 @@
 "RESTART_LOCALIZATION_MESSAGE"="The localization will be restarted. This should be used when the robot is stopped.";
 
 //Resource Download Alert View
-"RetryAlert" = "Check the connection with the server!";
+"Retry Alert" = "Check the connection with the server!";
 "Retry" = "Retry";
-"ReturnMainmenu" = "ReturnMainMenu";
-"ResourceDownload" = "Resource Download";
+"Return Mainmenu" = "Return MainMenu";
+"Resource Download" = "Resource Download";

--- a/CaBot/ja.lproj/Localizable.strings
+++ b/CaBot/ja.lproj/Localizable.strings
@@ -296,3 +296,4 @@
 //Resource Download Alert View
 "RetryAlert" = "サーバーとの接続をご確認ください！";
 "Retry" = "リトライ";
+"ReturnMainmenu" = "メインメニューに戻る";

--- a/CaBot/ja.lproj/Localizable.strings
+++ b/CaBot/ja.lproj/Localizable.strings
@@ -292,3 +292,7 @@
 "Restart Localization"="位置推定の再試行";
 "Restarting Localization"="位置推定中";
 "RESTART_LOCALIZATION_MESSAGE"="位置推定が再試行されます。必ずロボットが停止した状態で行ってください。";
+
+//Resource Download Alert View
+"RetryAlert" = "サーバーとの接続をご確認ください！";
+"Retry" = "リトライ";

--- a/CaBot/ja.lproj/Localizable.strings
+++ b/CaBot/ja.lproj/Localizable.strings
@@ -297,3 +297,4 @@
 "RetryAlert" = "サーバーとの接続をご確認ください！";
 "Retry" = "リトライ";
 "ReturnMainmenu" = "メインメニューに戻る";
+"ResourceDownload" = "リソースのダウンロード";

--- a/CaBot/ja.lproj/Localizable.strings
+++ b/CaBot/ja.lproj/Localizable.strings
@@ -294,7 +294,7 @@
 "RESTART_LOCALIZATION_MESSAGE"="位置推定が再試行されます。必ずロボットが停止した状態で行ってください。";
 
 //Resource Download Alert View
-"RetryAlert" = "サーバーとの接続をご確認ください！";
+"Retry Alert" = "サーバーとの接続をご確認ください！";
 "Retry" = "リトライ";
-"ReturnMainmenu" = "メインメニューに戻る";
-"ResourceDownload" = "リソースのダウンロード";
+"Return Mainmenu" = "メインメニューに戻る";
+"Resource Download" = "リソースのダウンロード";


### PR DESCRIPTION
タスク＃250（アプリのデータ読み込みをオンラインリソースを前提としたものに書き換える）が実装しました。
アプリ起動時にハッシュ値とリソースをzipしたファイルをMapServiceからダウンロードして、アプリのDocumentディレクトリに展開するのが実装しました。再度ダウンロードする前にハッシュ値を比較してから、ハッシュ値が同じであれば、ダウンロードせず、逆にダウンロードが行います。
サーバーへアクセスできない異常系でメインメニュー画面の上にエラーメッセージとリトライボタンが表示される。リトライボタンを押して、再度サーバーへサクセスを試すことができます。
以上の機能が実装しましたので、お手数ですが、ご確認のほど宜しくお願い致します。