### PR TITLE
アテンドアプリからユーザアプリの目的地をクリアできるように

### DIFF
--- a/CaBot/Views/Attend/MainMenuView.swift
+++ b/CaBot/Views/Attend/MainMenuView.swift
@@ -73,8 +73,36 @@ struct MainMenuView: View {
 struct UserInfoDestinations: View {
     @EnvironmentObject var modelData: CaBotAppModel
 
+    @State private var isConfirming = false
+    @State private var targetTour: Tour?
     var body: some View {
         Form {
+            Section(header: Text("Actions")) {
+                Button(action: {
+                    isConfirming = true
+                }) {
+                    Label{
+                        Text("CANCEL_NAVIGATION")
+                    } icon: {
+                        Image(systemName: "xmark.circle")
+                    }
+                }
+                .confirmationDialog(Text("CANCEL_NAVIGATION"), isPresented: $isConfirming) {
+                    Button {
+                        modelData.clearAll()
+                        NavigationUtil.popToRootView()
+                        modelData.share(user_info: SharedInfo(type: .ClearDestinations, value: ""))
+                        
+                    } label: {
+                        Text("CANCEL_ALL")
+                    }
+                    Button("Cancel", role: .cancel) {
+                    }
+                } message: {
+                    let message = LocalizedStringKey("CANCEL_NAVIGATION_MESSAGE \(modelData.tourManager.destinationCount, specifier: "%d")")
+                    Text(message)
+                }
+            }
             Section(header: Text("Tour")) {
                 ForEach(modelData.userInfo.destinations, id: \.self) { destination in
                     Label {

--- a/CaBot/Views/Attend/MainMenuView.swift
+++ b/CaBot/Views/Attend/MainMenuView.swift
@@ -99,7 +99,7 @@ struct UserInfoDestinations: View {
                     Button("Cancel", role: .cancel) {
                     }
                 } message: {
-                    let message = LocalizedStringKey("CANCEL_NAVIGATION_MESSAGE \(modelData.tourManager.destinationCount, specifier: "%d")")
+                    let message = LocalizedStringKey("CANCEL_NAVIGATION_MESSAGE \(modelData.userInfo.destinations.count, specifier: "%d")")
                     Text(message)
                 }
             }
@@ -174,7 +174,7 @@ struct UserInfoView: View {
                     }
                 }
             }
-            if (modelData.userInfo.destinations.count > 1) {
+            if (modelData.userInfo.destinations.count >= 1) {
                 NavigationLink(destination: UserInfoDestinations().environmentObject(modelData), label: {
                     HStack {
                         Spacer()


### PR DESCRIPTION
AttendアプリのMainMenuViewクラスにツアーをクリアする処理を追加しました