### PR TITLE
Add 'Prepend destination' option for individual additions in attend app

### DIFF
--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -518,7 +518,7 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
             updateNetworkConfig()
         }
     }
-    let socketPort: String = "5000"
+    let socketPort: String = "5001"
     let rosPort: String = "9091"
     @Published var menuDebug: Bool = false {
         didSet {
@@ -1064,9 +1064,9 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
         userInfo.clear()
     }
 
-    func share(destination: Destination, clear: Bool = true) {
+    func share(destination: Destination, clear: Bool = true, addFirst: Bool = false) {
         if let value = destination.value {
-            self.share(user_info: SharedInfo(type: .OverrideDestination, value: value, flag1: clear))
+            self.share(user_info: SharedInfo(type: .OverrideDestination, value: value, flag1: clear, flag2: addFirst))
             userInfo.clear()
         }
     }
@@ -1433,7 +1433,12 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
                                 if userInfo.flag1 { // clear and add
                                     self.clearAll()
                                 }
-                                tourManager.addToLast(destination: dest)
+                                if userInfo.flag2 {
+                                    tourManager.addToFirst(destination: dest)
+                                }
+                                else {
+                                    tourManager.addToLast(destination: dest)
+                                }
                                 needToStartAnnounce(wait: true)
                                 return
                             }

--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -518,7 +518,7 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
             updateNetworkConfig()
         }
     }
-    let socketPort: String = "5001"
+    let socketPort: String = "5000"
     let rosPort: String = "9091"
     @Published var menuDebug: Bool = false {
         didSet {

--- a/CaBot/Views/Attend/DestinationsView.swift
+++ b/CaBot/Views/Attend/DestinationsView.swift
@@ -62,8 +62,15 @@ struct DestinationsView: View {
                     } else {
                         HStack {
                             Button(action: {
-                                targetDestination = destination
-                                isConfirming = true
+                                if (modelData.userInfo.destinations.count > 0) {
+                                    targetDestination = destination
+                                    isConfirming = true
+                                } else {
+                                    // if there is no destination, start immediately
+                                    modelData.share(destination: destination, clear: false)
+                                    modelData.needToStartAnnounce(wait: true)
+                                    NavigationUtil.popToRootView()
+                                }
                             }){
                                 VStack(alignment: .leading) {
                                     Text(destination.title.text)

--- a/CaBot/Views/Attend/DestinationsView.swift
+++ b/CaBot/Views/Attend/DestinationsView.swift
@@ -112,8 +112,7 @@ struct DestinationsView: View {
                                     targetDestination = nil
                                 }
                             } message: { detail in
-                                let message = LocalizedStringKey("CANCEL_NAVIGATION_MESSAGE \(modelData.tourManager.destinationCount, specifier: "%d")")
-                                print("modelData.tourManager.destinationCount = \(modelData.tourManager)")
+                                let message = LocalizedStringKey("ADD_A_DESTINATION_MESSAGE \(modelData.userInfo.destinations.count, specifier: "%d")")
                                 Text(message)
                             }
                             Spacer()

--- a/CaBot/Views/Attend/DestinationsView.swift
+++ b/CaBot/Views/Attend/DestinationsView.swift
@@ -83,27 +83,37 @@ struct DestinationsView: View {
                             detail in
                                 Button {
                                     if let destination = targetDestination {
-                                        modelData.share(destination: destination, clear: false)
-                                        NavigationUtil.popToRootView()
-                                        targetDestination = nil
-                                    }
-                                } label: {
-                                    Text("ADD_DESTINATION")
-                                }
-                                Button {
-                                    if let destination = targetDestination {
                                         modelData.share(destination: destination)
                                         NavigationUtil.popToRootView()
                                         targetDestination = nil
                                     }
                                 } label: {
-                                    Text("CLEAR_AND_ADD_DESTINATION")
+                                    Text("CLEAR_ALL_THEN_ADD")
+                                }
+                                Button {
+                                    if let destination = targetDestination {
+                                        modelData.share(destination: destination, clear: false, addFirst: true)
+                                        NavigationUtil.popToRootView()
+                                        targetDestination = nil
+                                    }
+                                } label: {
+                                    Text("ADD_TO_FIRST")
+                                }
+                                Button {
+                                    if let destination = targetDestination {
+                                        modelData.share(destination: destination, clear: false)
+                                        NavigationUtil.popToRootView()
+                                        targetDestination = nil
+                                    }
+                                } label: {
+                                    Text("ADD_TO_LAST")
                                 }
                                 Button("Cancel", role: .cancel) {
                                     targetDestination = nil
                                 }
                             } message: { detail in
-                                let message = LocalizedStringKey("SEND_DESTINATION_MESSAGE \(detail.title.text)")
+                                let message = LocalizedStringKey("CANCEL_NAVIGATION_MESSAGE \(modelData.tourManager.destinationCount, specifier: "%d")")
+                                print("modelData.tourManager.destinationCount = \(modelData.tourManager)")
                                 Text(message)
                             }
                             Spacer()


### PR DESCRIPTION
アテンドアプリから個別目的地を追加する際も「目的地の最初に追加」ができるようにする
https://github.com/CMU-cabot/TODO-Consortium/issues/364