### PR TITLE
Sync attend app language settings to user app on startup

### DIFF
--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -1184,6 +1184,9 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
                 if self.modeType != .Normal{
                     self.share(user_info: SharedInfo(type: .RequestUserInfo, value: ""))
                 }
+                else if self.modeType == .Normal{
+                    self.share(user_info: SharedInfo(type: .ChangeLanguage, value: self.resourceLang))
+                }
                 DispatchQueue.main.async {
                     _ = self.fallbackService.manage(command: .lang, param: self.resourceLang)
                 }


### PR DESCRIPTION
下記対応を実施しました。
ご確認よろしくお願いいたします。

【要対応】アプリの言語設定の同期
アテンドアプリを英語の状態にして，日本語の状態のユーザアプリを起動してもアテンドアプリに反映されない
https://github.com/CMU-cabot/TODO-Consortium/issues/436