### PR TITLE
Modify user voice on attend side and play on user side

### DIFF
--- a/CaBot/CaBotAppModel.swift
+++ b/CaBot/CaBotAppModel.swift
@@ -1479,10 +1479,12 @@ final class CaBotAppModel: NSObject, ObservableObject, CaBotServiceDelegateBLE, 
         if userInfo.type == .ChangeUserVoiceRate {
             self.userSpeechRate = Double(userInfo.value) ?? 0.5
             self.updateTTS()
+            self.playSample(mode: .User)
         }
         if userInfo.type == .ChangeUserVoiceType {
             self.userVoice = TTSHelper.getVoice(by: userInfo.value)
             self.updateTTS()
+            self.playSample(mode: .User)
         }
     }
 

--- a/CaBot/Views/Attend/SettingView.swift
+++ b/CaBot/Views/Attend/SettingView.swift
@@ -136,7 +136,6 @@ struct SettingView: View {
                 }.onChange(of: modelData.userVoice, perform: { value in
                     if let voice = modelData.userVoice {
                         if !isResourceChanging {
-                            modelData.playSample(mode: VoiceMode.User)
                             modelData.share(user_info: SharedInfo(type: .ChangeUserVoiceType, value: "\(voice.id)"))
                         }
                     }
@@ -154,7 +153,6 @@ struct SettingView: View {
                            onEditingChanged: { editing in
                             timer?.invalidate()
                             timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { timer in
-                                modelData.playSample(mode: VoiceMode.User)
                                 modelData.share(user_info: SharedInfo(type: .ChangeUserVoiceRate, value: "\(modelData.userSpeechRate)"))
                             }
                     })

--- a/CaBot/Views/User/SettingView.swift
+++ b/CaBot/Views/User/SettingView.swift
@@ -75,7 +75,6 @@ struct SettingView: View {
                         if !isResourceChanging {
                             if(userVoicePickerSelection != modelData.userVoice){
                                 modelData.userVoice = value
-                                modelData.playSample(mode: VoiceMode.User)
                                 modelData.share(user_info: SharedInfo(type: .ChangeUserVoiceType, value: "\(voice.id)"))
                             }
                             userVoicePickerSelection = value
@@ -102,7 +101,6 @@ struct SettingView: View {
                            onEditingChanged: { editing in
                             timer?.invalidate()
                             timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { timer in
-                                modelData.playSample(mode: VoiceMode.User)
                                 modelData.share(user_info: SharedInfo(type: .ChangeUserVoiceRate, value: "\(modelData.userSpeechRate)"))
                             }
                     })


### PR DESCRIPTION
下記動作で実装しております。

> アテンド側でユーザー音声速度を変えた時には、アテンド側ではplay sampleせずにユーザーに変更だけ送り、ユーザー側で変更した時と同じ挙動
https://github.com/CMU-cabot/TODO-Consortium/issues/436#issuecomment-2342416011

現状ではユーザーからアテンドにしゃべらせる関係でアテンドアプリではアテンドアプリの音声設定に沿ってボイスが再生されます。（アテンドアプリでユーザーのボイス設定を変更してもアテンドのボイス設定になっているとそちらの設定で読み上げられます。）
下記と同じ動作になります。
> 3でユーザアプリの設定が変更された際にアテンドアプリの設定で読み上げるのはあり？
こちらは音声選択をアテンド音声にしているので違和感がない気もする
https://github.com/CMU-cabot/TODO-Consortium/issues/436#issue-2453203555